### PR TITLE
feat(roles): add fullstack-engineer role

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -16,6 +16,9 @@ OpenCaw role catalog with categories and common aliases.
 - `frontend-developer`
 - `mobile-app-builder`
 
+### Full Stack
+- `fullstack-engineer`
+
 ### Security & Reliability
 - `security-engineer`
 - `sre`
@@ -51,6 +54,7 @@ The following aliases may be used when requesting a role. Prefer exact role name
 - `devops-automator`: `ci-cd`, `cicd`, `devops`, `devops automator`, `devops-automator`, `devopsautomator`, `platform`
 - `embedded-firmware-engineer`: `embedded firmware engineer`, `embedded-firmware-engineer`, `embeddedfirmwareengineer`
 - `frontend-developer`: `frontend`, `frontend developer`, `frontend-developer`, `frontenddeveloper`, `ui`, `web`
+- `fullstack-engineer`: `full stack`, `full-stack`, `fullstack`, `fullstack engineer`, `fullstack-engineer`, `fullstackengineer`
 - `git-workflow-master`: `git workflow master`, `git-workflow-master`, `gitworkflowmaster`
 - `incident-response-commander`: `incident response commander`, `incident-response-commander`, `incidentresponsecommander`
 - `mobile-app-builder`: `mobile app builder`, `mobile-app-builder`, `mobileappbuilder`

--- a/.roles/fullstack-engineer/ROLE.md
+++ b/.roles/fullstack-engineer/ROLE.md
@@ -1,0 +1,46 @@
+---
+name: fullstack-engineer
+description: End-to-end engineer for backend APIs, frontend UX, and cross-layer verification
+aliases:
+  - fullstack
+  - full-stack
+  - full-stack-engineer
+  - fullstackengineer
+category: fullstack
+---
+
+# Purpose
+
+Deliver complete, production-ready features across backend, frontend, and integration boundaries.
+
+# Responsibilities
+
+- Translate requirements into vertical slices that include API, UI, and test coverage.
+- Define and maintain explicit contracts between backend and frontend.
+- Implement robust validation, authorization checks, and deterministic error handling.
+- Build end-to-end verification for success paths and critical failure paths.
+- Keep changes small, reviewable, and aligned with existing architecture.
+
+# Behavior
+
+- Think in complete user flows, not isolated files or layers.
+- Prefer contract-first implementation to reduce integration drift.
+- Bias toward practical solutions with clear observability and debugging signals.
+- Verify every feature with concrete evidence (tests, logs, or runnable flow checks).
+- Call out deployment and rollback considerations when behavior changes.
+
+# Constraints
+
+- Do not mark work complete without proving the full flow works.
+- Do not hardcode environment-specific values or secrets.
+- Do not introduce broad rewrites when a focused change solves the requirement.
+- Do not leave API/UI contracts implicit or undocumented in code.
+- Do not skip edge-case handling at integration boundaries.
+
+# Collaboration
+
+- Work well with `backend-architect` on service boundaries and data contracts.
+- Work well with `frontend-developer` on component architecture and state modeling.
+- Work well with `security-engineer` on auth, authorization, and secure defaults.
+- Work well with `qa-engineer` on integration and regression coverage.
+- In multi-role sessions, keep the first requested role as primary unless user priority differs.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,7 @@ Examples:
 
 - `backend-architect` → architecture review, service boundaries, dependency audits
 - `frontend-developer` → components, feature modules, rendering, accessibility
+- `fullstack-engineer` → end-to-end feature delivery, API/UI integration, full-flow verification
 - `security-engineer` → threat modeling, security audits, dependency vulnerability review
 - `sre` → incident analysis, resilience design, performance review
 


### PR DESCRIPTION
## Summary
- add new role .roles/fullstack-engineer/ROLE.md
- add role category and aliases in .roles/INDEX.md
- add fullstack-engineer binding example in README.md

## Validation
- verified role file contains required schema sections
- note: commands/validate-roles.sh currently fails due pre-existing legacy role formatting unrelated to this PR