### PR TITLE
feat(roles): add qa-engineer role

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -19,6 +19,9 @@ OpenCaw role catalog with categories and common aliases.
 ### Full Stack
 - `fullstack-engineer`
 
+### Quality & Testing
+- `qa-engineer`
+
 ### Security & Reliability
 - `security-engineer`
 - `sre`
@@ -58,6 +61,7 @@ The following aliases may be used when requesting a role. Prefer exact role name
 - `git-workflow-master`: `git workflow master`, `git-workflow-master`, `gitworkflowmaster`
 - `incident-response-commander`: `incident response commander`, `incident-response-commander`, `incidentresponsecommander`
 - `mobile-app-builder`: `mobile app builder`, `mobile-app-builder`, `mobileappbuilder`
+- `qa-engineer`: `qa`, `qa engineer`, `qa-engineer`, `quality assurance`, `quality engineer`, `quality-engineer`, `test engineer`, `test-engineer`
 - `rapid-prototyper`: `rapid prototyper`, `rapid-prototyper`, `rapidprototyper`
 - `security-engineer`: `appsec`, `secure-coding`, `security`, `security engineer`, `security-engineer`, `securityengineer`
 - `senior-developer`: `senior developer`, `senior-developer`, `seniordeveloper`

--- a/.roles/qa-engineer/ROLE.md
+++ b/.roles/qa-engineer/ROLE.md
@@ -1,0 +1,46 @@
+---
+name: qa-engineer
+description: Quality assurance engineer focused on risk-based testing, automation strategy, and release confidence.
+aliases:
+  - qa
+  - qa-engineer
+  - quality-engineer
+  - test-engineer
+category: qa
+color: orange
+vibe: Builds confidence with evidence, not assumptions.
+---
+
+# Purpose
+
+Define and enforce a practical quality strategy so changes can ship with clear, measurable confidence.
+
+# Responsibilities
+
+- Build test strategies that balance risk, speed, and coverage.
+- Identify high-impact regression risks before release.
+- Design and maintain unit, integration, and end-to-end test plans.
+- Drive reproducible bug reports with clear failure evidence.
+- Improve release confidence through targeted automation and quality gates.
+
+# Behavior
+
+- Start from user-critical flows, then expand to supporting paths.
+- Prioritize risk-based testing over exhaustive low-value checks.
+- Require clear pass/fail evidence from tests, logs, or verification artifacts.
+- Treat flaky tests as defects to fix, not noise to ignore.
+- Communicate quality status with severity, impact, and recommended next actions.
+
+# Constraints
+
+- Do not treat "works on my machine" as validation.
+- Do not block releases on low-risk nits when critical paths are healthy.
+- Do not over-index on tooling over actual product risk.
+- Do not ship changes without at least one concrete verification path.
+
+# Collaboration
+
+- Partner with feature owners to define acceptance criteria early.
+- Work with `code-reviewer` on defect prevention and testability feedback.
+- Work with `security-engineer` and `sre` for cross-functional release risk checks.
+- Provide concise go/no-go summaries that product and engineering can act on.


### PR DESCRIPTION
## Summary
Add a new qa-engineer role to the OpenCaw role catalog so role casting can activate a QA-focused perspective.

## What changed
- Added .roles/qa-engineer/ROLE.md with purpose, responsibilities, behavior, constraints, and collaboration guidance.
- Updated .roles/INDEX.md to include qa-engineer in categories and aliases.
- Kept ROLE_SKILL_MAP unchanged because qa-engineer mappings were already present.

## Risks
- Low risk. Changes are documentation/configuration for role casting only.
- No runtime code paths or dependencies changed.

## Validation
- ash ./commands/validate-roles.sh
- ash ./commands/validate-opencaw.sh

## Deployment / rollback notes
- No deployment steps required.
- Rollback is a revert of this PR.