### PR TITLE
feat(roles): add code-migrator role and migration workflow

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -22,6 +22,9 @@ OpenCaw role catalog with categories and common aliases.
 ### Quality & Testing
 - `qa-engineer`
 
+### Migration & Modernization
+- `code-migrator`
+
 ### Security & Reliability
 - `security-engineer`
 - `sre`
@@ -51,6 +54,7 @@ The following aliases may be used when requesting a role. Prefer exact role name
 - `ai-engineer`: `ai`, `ai engineer`, `ai-engineer`, `aiengineer`, `llm`, `ml`
 - `autonomous-optimization-architect`: `architect`, `autonomous optimization architect`, `autonomous-optimization-architect`, `autonomousoptimizationarchitect`
 - `backend-architect`: `api`, `api-architect`, `architect`, `backend`, `backend architect`, `backend-architect`, `backendarchitect`
+- `code-migrator`: `code migrator`, `code-migrator`, `codemigrator`, `migration-engineer`, `modernization-engineer`
 - `code-reviewer`: `code reviewer`, `code-reviewer`, `codereviewer`
 - `data-engineer`: `analytics`, `data`, `data engineer`, `data-engineer`, `dataengineer`
 - `database-optimizer`: `analytics`, `data`, `database optimizer`, `database-optimizer`, `databaseoptimizer`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -77,6 +77,22 @@
       "commands/generate-test-report.sh"
     ]
   },
+  "code-migrator": {
+    "skills": [
+      "framework-migration-plan",
+      "upgrade-dotnet-runtime",
+      "dependency-audit-dotnet",
+      "test-gap-analysis",
+      "regression-suite-update"
+    ],
+    "commands": [
+      "commands/dotnet-list-outdated-packages.sh",
+      "commands/dotnet-upgrade-assistant.sh",
+      "commands/dotnet-restore.sh",
+      "commands/dotnet-build.sh",
+      "commands/dotnet-test.sh"
+    ]
+  },
   "devops-engineer": {
     "skills": [
       "create-ci-pipeline",

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -96,6 +96,21 @@ Commands:
 - `commands/run-e2e.sh`
 - `commands/generate-test-report.sh`
 
+### code-migrator
+Skills:
+- `framework-migration-plan`
+- `upgrade-dotnet-runtime`
+- `dependency-audit-dotnet`
+- `test-gap-analysis`
+- `regression-suite-update`
+
+Commands:
+- `commands/dotnet-list-outdated-packages.sh`
+- `commands/dotnet-upgrade-assistant.sh`
+- `commands/dotnet-restore.sh`
+- `commands/dotnet-build.sh`
+- `commands/dotnet-test.sh`
+
 ### devops-engineer
 Skills:
 - `create-ci-pipeline`

--- a/.roles/code-migrator/ROLE.md
+++ b/.roles/code-migrator/ROLE.md
@@ -1,0 +1,48 @@
+---
+name: code-migrator
+description: Specialist for modernizing legacy codebases through safe, staged runtime and framework upgrades.
+aliases:
+  - code-migrator
+  - migrator
+  - modernization-engineer
+  - runtime-upgrade-engineer
+category: platform
+color: amber
+vibe: Migrates legacy systems without breaking production confidence.
+---
+
+# Purpose
+
+Lead and execute safe migrations from older technology stacks to modern versions while preserving business behavior and release reliability.
+
+# Responsibilities
+
+- Build migration plans with explicit phases, rollback points, and verification gates.
+- Inventory and upgrade framework/runtime dependencies with compatibility checks.
+- Identify and remediate breaking changes introduced by version upgrades.
+- Modernize build, test, and CI workflows to match upgraded platforms.
+- Preserve behavior through targeted regression and integration coverage.
+- Produce migration runbooks that teams can repeat across repositories.
+
+# Behavior
+
+- Prefer incremental migration slices over big-bang rewrites.
+- Start with baseline evidence (current tests/build behavior) before changing versions.
+- Use compatibility-first decisions: upgrade blockers first, then framework/runtime versions.
+- Surface migration risks early with concrete mitigation and fallback paths.
+- Treat ".NET Core to .NET 8" style upgrades as engineering changes that require verification, not just config edits.
+
+# Constraints
+
+- Do not change runtime/framework versions without a documented verification plan.
+- Do not remove compatibility shims until replacement behavior is proven.
+- Do not introduce broad refactors that obscure migration intent.
+- Do not assume successful compile equals successful migration.
+- Do not hardcode environment- or tenant-specific values during migration work.
+
+# Collaboration
+
+- Pair with `backend-architect` on layering and contract-preserving migration paths.
+- Pair with `qa-engineer` on regression strategy for upgraded codepaths.
+- Pair with `sre` on rollout safety, observability, and rollback criteria.
+- Coordinate with `security-engineer` when dependency/runtime changes affect security posture.

--- a/commands/dotnet-list-outdated-packages.sh
+++ b/commands/dotnet-list-outdated-packages.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd ..
+
+if [[ $# -eq 0 ]]; then
+  echo "Listing outdated NuGet packages for the current solution context..."
+  dotnet list package --outdated
+else
+  target="$1"
+  shift || true
+  echo "Listing outdated NuGet packages for: $target"
+  dotnet list "$target" package --outdated "$@"
+fi

--- a/commands/dotnet-upgrade-assistant.sh
+++ b/commands/dotnet-upgrade-assistant.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd ..
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: ./commands/dotnet-upgrade-assistant.sh <solution-or-project-path> [extra upgrade-assistant args...]" >&2
+  exit 1
+fi
+
+target="$1"
+shift || true
+
+tool_cmd=""
+
+if command -v upgrade-assistant >/dev/null 2>&1; then
+  tool_cmd="upgrade-assistant"
+elif [[ -x "$HOME/.dotnet/tools/upgrade-assistant" ]]; then
+  tool_cmd="$HOME/.dotnet/tools/upgrade-assistant"
+else
+  echo "Installing or updating upgrade-assistant global tool..."
+  dotnet tool update -g upgrade-assistant >/dev/null 2>&1 || dotnet tool install -g upgrade-assistant >/dev/null 2>&1
+
+  if command -v upgrade-assistant >/dev/null 2>&1; then
+    tool_cmd="upgrade-assistant"
+  elif [[ -x "$HOME/.dotnet/tools/upgrade-assistant" ]]; then
+    tool_cmd="$HOME/.dotnet/tools/upgrade-assistant"
+  else
+    echo "Unable to locate upgrade-assistant. Ensure ~/.dotnet/tools is on PATH and retry." >&2
+    exit 1
+  fi
+fi
+
+echo "Running upgrade-assistant for: $target"
+"$tool_cmd" upgrade "$target" "$@"

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -29,6 +29,11 @@ Common reusable skills included in OpenCaw by category.
 - `refactor-service` — Refactor a backend service or application workflow.
 - `optimize-query` — Improve data access or query efficiency safely.
 
+## Migration
+
+- `framework-migration-plan` — Define a phased migration strategy from legacy frameworks/runtimes to modern supported versions.
+- `upgrade-dotnet-runtime` — Execute .NET runtime/framework upgrades with verification-focused follow-through.
+
 ## Frontend
 
 - `generate-component` — Create or revise a frontend component with clear boundaries and responsibilities.

--- a/skills/framework-migration-plan/SKILL.md
+++ b/skills/framework-migration-plan/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: framework-migration-plan
+description: Build a staged migration plan from legacy frameworks/runtimes to modern supported versions with explicit risk controls.
+---
+
+## When to use
+Use when upgrading a codebase from an older runtime or framework version (for example, .NET Core to .NET 8) and you need a safe, testable migration path.
+
+## Output
+- current-state baseline (runtime, framework, package constraints)
+- target-state definition and compatibility assumptions
+- phased migration plan with checkpoints
+- breaking-change and dependency risk matrix
+- rollback and verification strategy per phase
+
+## Notes
+- Prefer incremental migration over one-shot rewrites.
+- Require validation evidence after each phase before continuing.

--- a/skills/upgrade-dotnet-runtime/SKILL.md
+++ b/skills/upgrade-dotnet-runtime/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: upgrade-dotnet-runtime
+description: Execute and verify .NET runtime/framework upgrades with minimal behavioral drift.
+---
+
+## When to use
+Use when modernizing .NET projects or solutions to newer target frameworks such as .NET 8.
+
+## Command
+../commands/dotnet-upgrade-assistant.sh
+
+## Output
+- selected solution/project migration target
+- upgrade execution result summary
+- breaking changes or manual follow-up list
+- post-upgrade restore/build/test status
+
+## Notes
+- Pair with `framework-migration-plan` before executing large upgrades.
+- Follow with package auditing and regression verification.


### PR DESCRIPTION
## Summary
Add a new code-migrator role to OpenCaw focused on safely upgrading legacy projects to modern runtimes/frameworks (for example, .NET Core to .NET 8).

## What changed
- Added role definition at .roles/code-migrator/ROLE.md with migration-first behavior, constraints, and collaboration guidance.
- Added role index entries and aliases in .roles/INDEX.md.
- Added migration role bindings in .roles/ROLE_SKILL_MAP.md and .roles/ROLE_SKILL_MAP.json.
- Added migration skills:
  - skills/framework-migration-plan/SKILL.md
  - skills/upgrade-dotnet-runtime/SKILL.md
- Added migration commands:
  - commands/dotnet-upgrade-assistant.sh
  - commands/dotnet-list-outdated-packages.sh
- Updated skills/INDEX.md with a new Migration section.

## Risks
- Low to medium: baseline-only changes, but they affect role/skill/command selection behavior.
- No product runtime behavior is changed by this PR.

## Validation
- Bash ./commands/validate-roles.sh
- Bash ./commands/validate-skills.sh
- Bash ./commands/validate-commands.sh
- Bash ./commands/validate-opencaw.sh

## Deployment / rollback notes
- No deployment required.
- Rollback by reverting this PR.