### PR TITLE
feat: add clean-context skill and context cleanup commands

### DIFF
--- a/commands/archive-task-context.sh
+++ b/commands/archive-task-context.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+task_ref="${1:-}"
+
+if [[ -z "$task_ref" ]]; then
+  echo 'Usage: ./commands/archive-task-context.sh "<task-name|../tasks/<task-name>/TASK.md>"' >&2
+  exit 1
+fi
+
+if [[ "$task_ref" == */TASK.md ]]; then
+  task_file="$task_ref"
+elif [[ "$task_ref" == *.md ]]; then
+  task_file="$task_ref"
+else
+  task_file="../tasks/$task_ref/TASK.md"
+fi
+
+if [[ ! -f "$task_file" ]]; then
+  echo "Task file not found: $task_file" >&2
+  exit 1
+fi
+
+task_name="$(basename "$(dirname "$task_file")")"
+
+if grep -Eq '^Archived on [0-9]{8}T[0-9]{6}Z\.$' "$task_file"; then
+  echo "ARCHIVED_TASK=$task_name"
+  echo 'ALREADY_ARCHIVED=true'
+  echo "TASK_FILE_COMPRESSED=$task_file"
+  exit 0
+fi
+
+archive_dir="../.ai/TASKS/completed"
+mkdir -p "$archive_dir"
+
+timestamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+archive_file="$archive_dir/${task_name}-${timestamp}.md"
+cp "$task_file" "$archive_file"
+
+extract_first_line_in_section() {
+  local file="$1"
+  local section="$2"
+
+  awk -v section="$section" '
+    BEGIN { in_section = 0 }
+    {
+      line = $0
+      sub(/\r$/, "", line)
+
+      if (line ~ "^##[[:space:]]+" section "[[:space:]]*$") {
+        in_section = 1
+        next
+      }
+
+      if (in_section && line ~ "^##[[:space:]]+") {
+        exit
+      }
+
+      if (in_section) {
+        candidate = line
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", candidate)
+        sub(/^-+[[:space:]]*/, "", candidate)
+
+        if (candidate != "") {
+          print candidate
+          exit
+        }
+      }
+    }
+  ' "$file"
+}
+
+extract_title() {
+  local file="$1"
+
+  awk '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+      if (line ~ /^#[[:space:]]+/) {
+        sub(/^#[[:space:]]+/, "", line)
+        print line
+        exit
+      }
+    }
+  ' "$file"
+}
+
+title="$(extract_title "$archive_file")"
+if [[ -z "$title" ]]; then
+  title="$task_name"
+fi
+
+goal_line="$(extract_first_line_in_section "$archive_file" 'Goal')"
+if [[ -z "$goal_line" ]]; then
+  goal_line='See archived task details.'
+fi
+
+review_line="$(extract_first_line_in_section "$archive_file" 'Review')"
+if [[ -z "$review_line" ]]; then
+  review_line='No explicit review summary found in source note.'
+fi
+
+cat > "$task_file" <<EOF
+# $title
+
+## Status
+Archived on $timestamp.
+
+## Archive
+- $archive_file
+
+## Durable Summary
+- Goal: $goal_line
+- Review: $review_line
+EOF
+
+echo "ARCHIVED_TASK=$task_name"
+echo "ARCHIVE_FILE=$archive_file"
+echo "TASK_FILE_COMPRESSED=$task_file"

--- a/commands/clean-context.sh
+++ b/commands/clean-context.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+todo_file="../tasks/TODO.md"
+active_dir="../.ai/TASKS/active"
+completed_dir="../.ai/TASKS/completed"
+
+archive_stale_active='false'
+stale_days='30'
+dry_run='false'
+
+usage() {
+  cat <<USAGE
+Usage: ./commands/clean-context.sh [--archive-stale-active] [--stale-days <days>] [--dry-run]
+
+Options:
+  --archive-stale-active   Archive active notes older than stale-days (unless they contain KEEP_ACTIVE).
+  --stale-days <days>      Age threshold used with --archive-stale-active. Default: 30.
+  --dry-run                Print what would change without writing files.
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --archive-stale-active)
+      archive_stale_active='true'
+      shift
+      ;;
+    --stale-days)
+      stale_days="${2:-}"
+      if [[ -z "$stale_days" || ! "$stale_days" =~ ^[0-9]+$ ]]; then
+        echo 'Expected integer after --stale-days.' >&2
+        exit 1
+      fi
+      shift 2
+      ;;
+    --dry-run)
+      dry_run='true'
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+mkdir -p "$active_dir" "$completed_dir"
+
+archived_task_count=0
+archived_active_count=0
+retained_active_count=0
+archived_task_names=''
+archived_active_names=''
+
+if [[ -f "$todo_file" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[0-9]+\.[[:space:]]+\[x\][[:space:]].*\`tasks/([^/]+)/TASK\.md\` ]]; then
+      task_name="${BASH_REMATCH[1]}"
+      task_file="../tasks/$task_name/TASK.md"
+
+      if [[ -f "$task_file" ]]; then
+        if grep -Eq '^Archived on [0-9]{8}T[0-9]{6}Z\.$' "$task_file"; then
+          continue
+        fi
+
+        if [[ "$dry_run" == 'true' ]]; then
+          echo "DRY_RUN archive task context: $task_name"
+          archived_task_count=$((archived_task_count + 1))
+          archived_task_names+="- $task_name\n"
+        else
+          archive_output="$("${script_dir}/archive-task-context.sh" "$task_name")"
+          if ! printf '%s\n' "$archive_output" | grep -q '^ALREADY_ARCHIVED=true$'; then
+            archived_task_count=$((archived_task_count + 1))
+            archived_task_names+="- $task_name\n"
+          fi
+        fi
+      fi
+    fi
+  done < "$todo_file"
+fi
+
+for note in "$active_dir"/*.md; do
+  [[ -e "$note" ]] || break
+
+  should_archive='false'
+
+  if grep -Eiq 'status:[[:space:]]*(completed|resolved)|^##[[:space:]]*Review' "$note"; then
+    should_archive='true'
+  fi
+
+  if [[ "$should_archive" == 'false' && "$archive_stale_active" == 'true' ]]; then
+    if ! grep -Eiq 'KEEP_ACTIVE|BLOCKER' "$note"; then
+      if find "$note" -mtime "+$stale_days" -print -quit | grep -q .; then
+        should_archive='true'
+      fi
+    fi
+  fi
+
+  if [[ "$should_archive" == 'true' ]]; then
+    note_name="$(basename "$note" .md)"
+    target="$completed_dir/${note_name}-$(date -u '+%Y%m%dT%H%M%SZ').md"
+
+    if [[ "$dry_run" == 'true' ]]; then
+      echo "DRY_RUN archive active note: $note -> $target"
+    else
+      cp "$note" "$target"
+      rm "$note"
+    fi
+
+    archived_active_count=$((archived_active_count + 1))
+    archived_active_names+="- $target\n"
+  else
+    retained_active_count=$((retained_active_count + 1))
+  fi
+done
+
+memory_merged=0
+rules_removed=0
+debug_compressed=0
+summary_file='(dry-run)'
+snapshot_dir='(dry-run)'
+
+if [[ "$dry_run" == 'false' ]]; then
+  summarize_output="$("${script_dir}/summarize-memory.sh")"
+  memory_merged="$(printf '%s\n' "$summarize_output" | awk -F= '/^MEMORY_DUPLICATES_MERGED=/{print $2; exit}')"
+  rules_removed="$(printf '%s\n' "$summarize_output" | awk -F= '/^RULE_DUPLICATES_REMOVED=/{print $2; exit}')"
+  debug_compressed="$(printf '%s\n' "$summarize_output" | awk -F= '/^DEBUG_NOTES_COMPRESSED=/{print $2; exit}')"
+  summary_file="$(printf '%s\n' "$summarize_output" | awk -F= '/^SUMMARY_FILE=/{print $2; exit}')"
+  snapshot_dir="$(printf '%s\n' "$summarize_output" | awk -F= '/^SNAPSHOT_DIR=/{print $2; exit}')"
+fi
+
+report_file="$completed_dir/clean-context-report-$(date -u '+%Y%m%dT%H%M%SZ').md"
+
+if [[ "$dry_run" == 'false' ]]; then
+  cat > "$report_file" <<EOF
+# Clean Context Report
+
+Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')
+
+## Active Items Retained
+- Active notes retained: $retained_active_count
+
+## Completed Items Archived
+- Completed tasks archived: $archived_task_count
+- Active notes archived: $archived_active_count
+
+### Archived Tasks
+${archived_task_names:-- none}
+
+### Archived Active Notes
+${archived_active_names:-- none}
+
+## Memory Cleanup
+- Memory entries merged: $memory_merged
+- Duplicate rules removed: $rules_removed
+- Debug notes compressed: $debug_compressed
+
+## Refreshed Summary
+- $summary_file
+
+## Traceability
+- Snapshot directory: $snapshot_dir
+EOF
+fi
+
+echo "ACTIVE_ITEMS_RETAINED=$retained_active_count"
+echo "COMPLETED_ITEMS_ARCHIVED=$((archived_task_count + archived_active_count))"
+echo "MEMORY_ENTRIES_MERGED=$memory_merged"
+echo "DUPLICATE_RULES_REMOVED=$rules_removed"
+echo "DEBUG_NOTES_COMPRESSED=$debug_compressed"
+echo "CONTEXT_SUMMARY_REFRESHED=$summary_file"
+echo "REPORT_FILE=$report_file"

--- a/commands/summarize-memory.sh
+++ b/commands/summarize-memory.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ai_dir="../.ai"
+archive_dir="$ai_dir/TASKS/completed/context-snapshots"
+memory_file="$ai_dir/MEMORY.md"
+rules_file="$ai_dir/RULES.md"
+debug_file="$ai_dir/DEBUG.md"
+summary_file="$ai_dir/CONTEXT_SUMMARY.md"
+todo_file="../tasks/TODO.md"
+architecture_file="../ARCHITECTURE.md"
+
+timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+fs_timestamp="$(date -u '+%Y%m%dT%H%M%SZ')"
+
+mkdir -p "$ai_dir" "$archive_dir"
+
+ensure_file() {
+  local file="$1"
+  local header="$2"
+
+  if [[ ! -f "$file" ]]; then
+    printf "%s\n\n" "$header" > "$file"
+  fi
+}
+
+ensure_file "$memory_file" '# Project Memory'
+ensure_file "$rules_file" '# Rules'
+ensure_file "$debug_file" '# Debug History'
+
+cp "$memory_file" "$archive_dir/MEMORY-$fs_timestamp.md"
+cp "$rules_file" "$archive_dir/RULES-$fs_timestamp.md"
+cp "$debug_file" "$archive_dir/DEBUG-$fs_timestamp.md"
+
+dedupe_bullets_in_place() {
+  local file="$1"
+  local before after
+
+  before="$(grep -Ec '^[[:space:]]*-[[:space:]]+' "$file" || true)"
+
+  awk '
+    {
+      line = $0
+      sub(/\r$/, "", line)
+
+      if (line ~ /^[[:space:]]*-[[:space:]]+/) {
+        item = line
+        sub(/^[[:space:]]*-[[:space:]]+/, "", item)
+
+        key = tolower(item)
+        gsub(/[[:space:]]+/, " ", key)
+        gsub(/^[[:space:]]+|[[:space:]]+$/, "", key)
+
+        if (key == "" || seen[key]++) {
+          next
+        }
+
+        print "- " item
+        next
+      }
+
+      print line
+    }
+  ' "$file" > "$file.tmp"
+
+  mv "$file.tmp" "$file"
+
+  after="$(grep -Ec '^[[:space:]]*-[[:space:]]+' "$file" || true)"
+  echo $((before - after))
+}
+
+memory_merged="$(dedupe_bullets_in_place "$memory_file")"
+rules_merged="$(dedupe_bullets_in_place "$rules_file")"
+debug_merged="$(dedupe_bullets_in_place "$debug_file")"
+
+list_bullets() {
+  local file="$1"
+  local limit="$2"
+  local content
+
+  content="$(grep -E '^[[:space:]]*-[[:space:]]+' "$file" | sed -E 's/^[[:space:]]*-[[:space:]]+/- /' | head -n "$limit" || true)"
+
+  if [[ -z "$content" ]]; then
+    echo '- none'
+    return
+  fi
+
+  echo "$content"
+}
+
+list_pending_todo() {
+  local limit="$1"
+
+  if [[ ! -f "$todo_file" ]]; then
+    echo '- TODO file not found.'
+    return
+  fi
+
+  local pending
+  pending="$(grep -E '^[0-9]+\.[[:space:]]+\[[[:space:]]\]' "$todo_file" | sed -E 's/^[0-9]+\.[[:space:]]+\[[[:space:]]\][[:space:]]+/- /' | head -n "$limit" || true)"
+
+  if [[ -z "$pending" ]]; then
+    echo '- none'
+    return
+  fi
+
+  echo "$pending"
+}
+
+active_note_count="0"
+if [[ -d "$ai_dir/TASKS/active" ]]; then
+  active_note_count="$(find "$ai_dir/TASKS/active" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')"
+fi
+
+completed_archive_count="0"
+if [[ -d "$ai_dir/TASKS/completed" ]]; then
+  completed_archive_count="$(find "$ai_dir/TASKS/completed" -maxdepth 1 -type f -name '*.md' | wc -l | tr -d ' ')"
+fi
+
+architecture_status='ARCHITECTURE.md not found.'
+if [[ -f "$architecture_file" ]]; then
+  architecture_status='ARCHITECTURE.md is present and authoritative.'
+fi
+
+cat > "$summary_file" <<EOF
+# Context Summary
+
+Generated: $timestamp
+
+## Active Items Retained
+$(list_pending_todo 8)
+
+## Current Constraints
+- $architecture_status
+- Active task notes: $active_note_count
+
+## Archive Snapshot
+- Completed archive files: $completed_archive_count
+- Snapshot directory: $archive_dir
+
+## Durable Memory
+$(list_bullets "$memory_file" 8)
+
+## Active Rules
+$(list_bullets "$rules_file" 8)
+
+## Debug Patterns
+$(list_bullets "$debug_file" 8)
+EOF
+
+echo "MEMORY_DUPLICATES_MERGED=$memory_merged"
+echo "RULE_DUPLICATES_REMOVED=$rules_merged"
+echo "DEBUG_NOTES_COMPRESSED=$debug_merged"
+echo "SUMMARY_FILE=$summary_file"
+echo "SNAPSHOT_DIR=$archive_dir"

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -6,6 +6,7 @@ Common reusable skills included in OpenCaw by category.
 
 - `plan-task` — Create or refine an implementation plan and keep task sequencing clear.
 - `update-memory` — Capture durable lessons in project-local memory files.
+- `clean-context` — Compress active context by archiving completed detail and refreshing a high-signal summary.
 - `debug-issue` — Diagnose an issue using logs, errors, tests, and observable evidence.
 - `review-code` — Review changes for correctness, maintainability, and alignment with architecture.
 - `refactor-code` — Improve structure while preserving behavior.

--- a/skills/clean-context/SKILL.md
+++ b/skills/clean-context/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: clean-context
+description: Clean and compress host-repository context by archiving completed task detail, deduplicating memory/rules/debug notes, and refreshing a high-signal context summary. Use after finishing tasks, before handoff, or when context artifacts become noisy.
+---
+
+## When to use
+Use when active context has grown noisy and you need to keep only high-signal artifacts for the next session.
+
+## Workflow
+1. Verify task changes first.
+2. Archive a specific completed task note when needed:
+   - `../commands/archive-task-context.sh "<task-name>"`
+3. Run full cleanup and summary refresh:
+   - `../commands/clean-context.sh`
+4. Optionally archive stale active notes:
+   - `../commands/clean-context.sh --archive-stale-active --stale-days 30`
+
+## Output
+- active items retained
+- completed items archived
+- memory entries merged
+- duplicate rules removed
+- debug notes compressed
+- recommended context summary refreshed
+
+## Safety rules
+- Never delete durable knowledge without archiving first.
+- Prefer summarization over destruction.
+- Keep `../.ai/MEMORY.md` short and high-value.
+- Preserve traceability via `../.ai/TASKS/completed/` snapshot and report files.


### PR DESCRIPTION
## Summary
Add a reusable `clean-context` capability to OpenCaw so sessions can keep active context small while preserving durable knowledge.

## What changed
- Added `skills/clean-context/SKILL.md` with workflow, output contract, and safety rules.
- Added `commands/clean-context.sh` to orchestrate cleanup and reporting.
- Added `commands/archive-task-context.sh` to archive and compress completed task notes.
- Added `commands/summarize-memory.sh` to snapshot and deduplicate memory/rules/debug notes and refresh `../.ai/CONTEXT_SUMMARY.md`.
- Updated `skills/INDEX.md` to register `clean-context` in Shared skills.

## Risks
- `clean-context.sh` archives completed task notes referenced in checked TODO entries; teams should confirm TODO checkmarks reflect real completion before running.
- Optional stale-note archival (`--archive-stale-active`) may archive notes that are still useful if they are old and not marked with `KEEP_ACTIVE` or `BLOCKER`.

## Validation
- `bash ./commands/validate-skills.sh`
- `bash ./commands/validate-commands.sh`
- `bash ./commands/validate-opencaw.sh`
- `bash -n ./commands/clean-context.sh`
- `bash -n ./commands/archive-task-context.sh`
- `bash -n ./commands/summarize-memory.sh`
- `bash ./commands/clean-context.sh --dry-run`

## Deployment / rollback notes
- No runtime deployment required; baseline tooling update only.
- Rollback by reverting commit `9008cdb` if needed.
