### PR TITLE
docs(agents): integrate clean-context workflow guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,6 +114,24 @@ When multiple roles are requested:
 - Ruthlessly iterate on lessons and rules until the same mistake rate drops
 - Prefer concise, normalized entries over verbose logs
 
+## Context hygiene workflow
+- Use the `clean-context` skill after substantial task completion, before handoff, or when context artifacts become noisy.
+- Follow this flow:
+  1. Finish implementation and verification.
+  2. Run `record-correction-pattern` or `record-debug-resolution` when applicable.
+  3. Run a safe preview: `./commands/clean-context.sh --dry-run`.
+  4. Run cleanup: `./commands/clean-context.sh`.
+- Expected outputs:
+  - active items retained
+  - completed items archived
+  - memory entries merged
+  - duplicate rules removed
+  - debug notes compressed
+  - recommended context summary refreshed
+- Safety rules:
+  - never delete durable knowledge without archiving it first
+  - prefer summarization over destruction
+
 ## Verification before done
 - Never mark a task complete without proving it works through tests, logs, or browser/playwright verification when relevant
 - Diff behavior between main and your changes when relevant
@@ -142,6 +160,7 @@ When multiple roles are requested:
 5. Keep `../tasks/TODO.md` concise: it should be the ordered checklist, not the full work log
 6. Store detailed implementation notes, task-specific instructions, and review results in the matching `../tasks/<unique_task_name>/TASK.md`
 7. Capture lessons: update `../.ai/MEMORY.md` after corrections or durable discoveries
+8. Before final handoff for substantial work, run `clean-context` to compress completed context and refresh high-signal summaries
 
 ## Task file rules
 - `../tasks/TODO.md` is the active ordered checklist only


### PR DESCRIPTION
## Summary
Update OpenCaw baseline instructions to explicitly use the `clean-context` skill at appropriate points in the delivery workflow.

## What changed
- Added a new `Context hygiene workflow` section in `AGENTS.md`.
- Documented when to use `clean-context` and the recommended run order:
  - finish implementation and verification
  - run correction/debug recording skills as needed
  - run `./commands/clean-context.sh --dry-run`
  - run `./commands/clean-context.sh`
- Added expected cleanup outputs and safety rules.
- Extended task management with a final-handoff step to run `clean-context` for substantial work.

## Risks
- Behavioral impact is documentation-only; no runtime or command logic changes.
- Guidance assumes `clean-context` command and skill are available in baseline.

## Validation
- Manual read-through of `AGENTS.md` for consistency and placement.
- Attempted: `bash ./commands/validate-opencaw.sh`
  - Result: failed due pre-existing unrelated skill metadata line-ending mismatches in `skills/clean-context`, `skills/framework-migration-plan`, and `skills/upgrade-dotnet-runtime` on current `main`.

## Deployment / rollback notes
- No deployment required.
- Rollback by reverting commit `cd3c2f0` if needed.