### PR TITLE
feat(baseline): enforce GitHub Actions and cloud preference order

### DIFF
--- a/.roles/SCHEMA.md
+++ b/.roles/SCHEMA.md
@@ -173,6 +173,21 @@ before falling back to other security tooling.
 
 ---
 
+# Cloud and CI Alignment Rules
+
+Role defaults must align to the OpenCaw cloud and pipeline baseline:
+
+1. Prefer `GitHub` for repository and collaboration workflows
+2. Prefer `GitHub Actions` for CI/CD automation and release orchestration
+3. Prefer cloud targets in this order when no user or repository override is provided:
+   1. `GCP`
+   2. `Azure`
+   3. `AWS`
+
+When a role recommends a different platform or execution path, it should call out why and what tradeoff drove that decision.
+
+---
+
 # Composition Rules
 
 Roles must support composition:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,15 @@ When multiple roles are requested:
 - Prefer keeping configuration externalized
 - Prefer deterministic, testable logic over hidden state or side effects
 
+## Cloud and CI conventions
+- Prefer `GitHub` for source control and collaboration defaults
+- Prefer `GitHub Actions` for CI/CD workflow defaults
+- Prefer cloud environment targets in this order unless the user explicitly overrides:
+  1. `GCP`
+  2. `Azure`
+  3. `AWS`
+- When providing cloud recommendations, migrations, or deployment plans, explain any deviation from this order
+
 ## Azure conventions
 - Prefer environment-driven configuration
 - Avoid hardcoding subscription, tenant, storage account, service bus, or resource names

--- a/commands/SCHEMA.md
+++ b/commands/SCHEMA.md
@@ -113,6 +113,21 @@ They must remain:
 
 ---
 
+# Cloud and CI Alignment Rules
+
+Commands related to repository automation, CI/CD, deployment, or infrastructure workflows should prefer:
+
+1. `GitHub` for repository-hosted automation context
+2. `GitHub Actions` for CI/CD execution paths
+3. Cloud targets in this order by default:
+   1. `GCP`
+   2. `Azure`
+   3. `AWS`
+
+When a command is intentionally platform-specific, document that scope clearly in command output or inline comments.
+
+---
+
 # Extensibility
 
 Commands should be:
@@ -138,4 +153,5 @@ Commands = execution layer
 Validation may be enforced with:
 
 - `./commands/validate-commands.sh`
+- `./commands/validate-cloud-preferences.sh`
 - `./commands/validate-opencaw.sh`

--- a/commands/validate-cloud-preferences.sh
+++ b/commands/validate-cloud-preferences.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+status=0
+
+files=(
+  "./AGENTS.md"
+  "./.roles/SCHEMA.md"
+  "./skills/SCHEMA.md"
+  "./commands/SCHEMA.md"
+)
+
+required_terms=(
+  "GitHub"
+  "GitHub Actions"
+  "GCP"
+  "Azure"
+  "AWS"
+)
+
+for file in "${files[@]}"; do
+  if [[ ! -f "$file" ]]; then
+    echo "Missing required file for cloud preference validation: $file" >&2
+    status=1
+    continue
+  fi
+
+  for term in "${required_terms[@]}"; do
+    if ! grep -Fq "$term" "$file"; then
+      echo "Missing required term '$term' in $file" >&2
+      status=1
+    fi
+  done
+
+  gcp_line="$(grep -n -m1 -E '\bGCP\b' "$file" | cut -d: -f1 || true)"
+  azure_line="$(grep -n -m1 -E '\bAzure\b' "$file" | cut -d: -f1 || true)"
+  aws_line="$(grep -n -m1 -E '\bAWS\b' "$file" | cut -d: -f1 || true)"
+
+  if [[ -z "$gcp_line" || -z "$azure_line" || -z "$aws_line" ]]; then
+    echo "Missing cloud ordering markers in $file" >&2
+    status=1
+    continue
+  fi
+
+  if ! [[ "$gcp_line" -lt "$azure_line" && "$azure_line" -lt "$aws_line" ]]; then
+    echo "Cloud order violation in $file (expected GCP -> Azure -> AWS)" >&2
+    status=1
+  fi
+done
+
+if [[ "$status" -eq 0 ]]; then
+  echo "Cloud preference validation passed."
+fi
+
+exit "$status"

--- a/commands/validate-opencaw.sh
+++ b/commands/validate-opencaw.sh
@@ -5,5 +5,6 @@ set -euo pipefail
 ./commands/validate-skills.sh
 ./commands/validate-commands.sh
 ./commands/validate-role-language-alignment.sh
+./commands/validate-cloud-preferences.sh
 
 echo "OpenCaw validation passed."

--- a/skills/SCHEMA.md
+++ b/skills/SCHEMA.md
@@ -88,6 +88,21 @@ Common categories:
 
 ---
 
+# Cloud and CI Alignment Rules
+
+Skills that involve source control, automation, CI/CD, deployment, or environment strategy must follow this baseline by default:
+
+1. Prefer `GitHub` for repository and collaboration workflows
+2. Prefer `GitHub Actions` for pipeline implementation and automation
+3. Prefer cloud targets in this order unless the user or host repository explicitly overrides:
+   1. `GCP`
+   2. `Azure`
+   3. `AWS`
+
+If a skill suggests an alternative stack, it should include a short rationale and note the compatibility impact.
+
+---
+
 # Validation Rules
 
 A skill is valid if:


### PR DESCRIPTION
## Summary
Establishes a baseline policy that all OpenCaw role/skill/command guidance should prefer GitHub + GitHub Actions, and cloud recommendations should default to `GCP -> Azure -> AWS` unless explicitly overridden.

## What changed
- Added `Cloud and CI conventions` to `AGENTS.md` with explicit preference order.
- Added `Cloud and CI Alignment Rules` to:
  - `.roles/SCHEMA.md`
  - `skills/SCHEMA.md`
  - `commands/SCHEMA.md`
- Added `commands/validate-cloud-preferences.sh` to enforce required markers and cloud order in canonical baseline files.
- Updated `commands/validate-opencaw.sh` to include `validate-cloud-preferences.sh`.

## Risks
- Low runtime risk: this PR changes baseline policy/docs and validation scripts, not production runtime code.
- Validation strictness risk: future schema edits that omit the cloud/CI markers will now fail OpenCaw validation.
- Existing CRLF behavior remains in repository scripts; execution in some bash environments may require normalization.

## Validation
Executed successfully (LF-normalized command input in Windows environment):
- `validate-cloud-preferences.sh`
- `validate-roles.sh`
- `validate-skills.sh`
- `validate-commands.sh`
- `validate-role-language-alignment.sh`

## Deployment / rollback notes
- No service deployment impact.
- Rollback is straightforward: revert this commit to remove policy/validator enforcement.
