### PR TITLE
feat(scaffold): append host AGENTS bootstrap on first run

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,27 @@ This allows you to modify instructions without affecting the upstream repository
 
 ---
 
+## First-run host bootstrap
+
+After installing OpenCaw, run:
+
+```bash
+./commands/create-host-ai-scaffold.sh
+```
+
+This command now:
+- creates the host repository `.ai` scaffold when missing
+- checks host root `AGENTS.md`
+- appends a managed OpenCaw bootstrap block only when missing
+
+If host `AGENTS.md` does not exist, it is created with the bootstrap block.
+If it exists, existing content is preserved and the bootstrap is appended idempotently.
+
+---
+
 # Examples
 
-First, while OpenCaw should auto load into sessions due AGENTS.md being standard. In the event this changes, or you just want to be sure. OpenCaw can be activated by first saying:
+OpenCaw should auto load in most sessions once the host bootstrap is present in root `AGENTS.md`. If needed, you can still force activation by saying:
 
 ```text
 activate opencaw in AGENTS.md

--- a/commands/create-host-ai-scaffold.sh
+++ b/commands/create-host-ai-scaffold.sh
@@ -1,27 +1,93 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-mkdir -p ../.ai/FRAGMENTS ../.ai/LEARNINGS ../.ai/tasks ../.ai/archive/tasks ../.ai/archive/context-snapshots ../.ai/reports
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+opencaw_root="$(cd "$script_dir/.." && pwd)"
+host_root="$(cd "$opencaw_root/.." && pwd)"
+host_ai_dir="$host_root/.ai"
+host_agents_file="$host_root/AGENTS.md"
 
-[[ -f ../.ai/MEMORY.md ]] || printf "# Project Memory\n\n" > ../.ai/MEMORY.md
-[[ -f ../.ai/RULES.md ]] || printf "# Rules\n\n" > ../.ai/RULES.md
-[[ -f ../.ai/DEBUG.md ]] || printf "# Debug History\n\n" > ../.ai/DEBUG.md
-[[ -f ../.ai/FRAGMENTS/repo-map.md ]] || printf "# Repository Map\n\n" > ../.ai/FRAGMENTS/repo-map.md
-[[ -f ../.ai/FRAGMENTS/conventions.md ]] || printf "# Conventions\n\n" > ../.ai/FRAGMENTS/conventions.md
-[[ -f ../.ai/FRAGMENTS/gotchas.md ]] || printf "# Gotchas\n\n" > ../.ai/FRAGMENTS/gotchas.md
-[[ -f ../.ai/LEARNINGS/workflows.md ]] || printf "# Workflows\n\n" > ../.ai/LEARNINGS/workflows.md
-[[ -f ../.ai/LEARNINGS/bugs.md ]] || printf "# Bug Patterns\n\n" > ../.ai/LEARNINGS/bugs.md
-mkdir -p ../.ai/tasks/example-task
+ensure_file() {
+  local path="$1"
+  local title="$2"
+  [[ -f "$path" ]] || printf "%s\n\n" "$title" > "$path"
+}
 
-if [[ ! -f ../.ai/tasks/TODO.md ]]; then
-  cat > ../.ai/tasks/TODO.md <<'EOF'
+ensure_host_agents_bootstrap() {
+  local mount_dir_name fallback_mount_path
+  mount_dir_name="$(basename "$opencaw_root")"
+  fallback_mount_path="./${mount_dir_name}/AGENTS.md"
+
+  local bootstrap_block
+  bootstrap_block="$(cat <<EOF
+<!-- OPENCAW_BOOTSTRAP_START -->
+## OpenCaw Bootstrap (Managed)
+
+Load and follow OpenCaw baseline instructions before applying repository-local instructions.
+
+Preferred baseline locations:
+- \`./.codex/AGENTS.md\`
+- \`./.cursor/AGENTS.md\`
+- \`./.claude/AGENTS.md\`
+
+Fallback for this repository:
+- \`${fallback_mount_path}\`
+
+If one of the paths exists, treat that file as the OpenCaw baseline source for the session.
+<!-- OPENCAW_BOOTSTRAP_END -->
+EOF
+)"
+
+  if [[ ! -f "$host_agents_file" ]]; then
+    cat > "$host_agents_file" <<EOF
+# AGENTS.md
+
+$bootstrap_block
+EOF
+    echo "Created host AGENTS bootstrap: $host_agents_file"
+    return
+  fi
+
+  if grep -Fq "OPENCAW_BOOTSTRAP_START" "$host_agents_file" \
+    || grep -Fq "$fallback_mount_path" "$host_agents_file"; then
+    echo "Host AGENTS bootstrap already present: $host_agents_file"
+    return
+  fi
+
+  printf "\n\n%s\n" "$bootstrap_block" >> "$host_agents_file"
+  echo "Appended OpenCaw bootstrap to existing host AGENTS: $host_agents_file"
+}
+
+ensure_host_agents_bootstrap
+
+mkdir -p \
+  "$host_ai_dir/FRAGMENTS" \
+  "$host_ai_dir/LEARNINGS" \
+  "$host_ai_dir/tasks" \
+  "$host_ai_dir/archive/tasks" \
+  "$host_ai_dir/archive/context-snapshots" \
+  "$host_ai_dir/reports"
+
+ensure_file "$host_ai_dir/MEMORY.md" "# Project Memory"
+ensure_file "$host_ai_dir/RULES.md" "# Rules"
+ensure_file "$host_ai_dir/DEBUG.md" "# Debug History"
+ensure_file "$host_ai_dir/FRAGMENTS/repo-map.md" "# Repository Map"
+ensure_file "$host_ai_dir/FRAGMENTS/conventions.md" "# Conventions"
+ensure_file "$host_ai_dir/FRAGMENTS/gotchas.md" "# Gotchas"
+ensure_file "$host_ai_dir/LEARNINGS/workflows.md" "# Workflows"
+ensure_file "$host_ai_dir/LEARNINGS/bugs.md" "# Bug Patterns"
+
+mkdir -p "$host_ai_dir/tasks/example-task"
+
+if [[ ! -f "$host_ai_dir/tasks/TODO.md" ]]; then
+  cat > "$host_ai_dir/tasks/TODO.md" <<'EOF'
 # TODO
 
 1. [ ] Example first task (`.ai/tasks/example-task/TASK.md`)
 EOF
 fi
 
-[[ -f ../.ai/tasks/example-task/TASK.md ]] || cat > ../.ai/tasks/example-task/TASK.md <<'EOF'
+[[ -f "$host_ai_dir/tasks/example-task/TASK.md" ]] || cat > "$host_ai_dir/tasks/example-task/TASK.md" <<'EOF'
 # Example first task
 
 ## Goal

--- a/skills/create-host-ai-scaffold/SKILL.md
+++ b/skills/create-host-ai-scaffold/SKILL.md
@@ -1,10 +1,15 @@
 ---
 name: create-host-ai-scaffold
-description: Create the recommended host repository .ai scaffold outside the mounted baseline.
+description: Create the recommended host repository .ai scaffold and ensure host AGENTS bootstrap points to OpenCaw when missing.
 ---
 
 ## When to use
-Use when the host repo does not yet have the expected .ai structure.
+Use when the host repo does not yet have the expected `.ai` structure or when OpenCaw bootstrap wiring is missing from the host root `AGENTS.md`.
+
+## Output
+- Host `.ai` directory structure exists with baseline memory/task files.
+- Host root `AGENTS.md` includes a managed OpenCaw bootstrap block.
+- Existing host `AGENTS.md` content is preserved; bootstrap block is appended only if missing.
 
 ## Command
 ../commands/create-host-ai-scaffold.sh


### PR DESCRIPTION
## Summary
Adds first-run OpenCaw bootstrap behavior so host root `AGENTS.md` is created or updated with a managed OpenCaw bootstrap block when missing.

## What changed
- Updated `commands/create-host-ai-scaffold.sh` to:
  - derive `host_root` and `host_ai_dir` from script location
  - create host `AGENTS.md` with OpenCaw bootstrap block if missing
  - append bootstrap block when host `AGENTS.md` exists but bootstrap is missing
  - remain idempotent on re-run (no duplicate bootstrap block)
  - preserve existing `.ai` scaffold creation behavior
- Updated `skills/create-host-ai-scaffold/SKILL.md` to document AGENTS bootstrap behavior and outputs.
- Updated `README.md` with a first-run bootstrap section and clarified auto-load behavior.

## Risks
- Low runtime risk: changes are to setup scaffolding and documentation, not product runtime paths.
- Content ownership risk: bootstrap block appends to existing host `AGENTS.md`; mitigated by managed markers and idempotent checks.

## Validation
- Functional scenario checks in temp mounts:
  - Missing host `AGENTS.md` -> created with bootstrap (`CASE1_CREATE=True`)
  - Existing host `AGENTS.md` without bootstrap -> appended while preserving content (`CASE2_APPEND_EXISTING=True`)
  - Re-run idempotency -> single bootstrap block remains (`CASE3_IDEMPOTENT=True`)
- Validators passed (LF-normalized execution in Windows environment):
  - `validate-skills.sh`
  - `validate-commands.sh`
  - `validate-roles.sh`
  - `validate-role-language-alignment.sh`

## Deployment / rollback notes
- No service deployment impact.
- Rollback: revert this PR commit.
