### PR TITLE
fix(startup): auto-run host scaffold on first run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,18 @@ Project-local knowledge belongs in the host repository:
 Never write project-specific learned state into this mounted baseline unless the user explicitly asks to modify the shared baseline.
 
 ## Session startup review
-At session start, review these host-repository files when they exist:
+At session start, ensure the host scaffold exists before loading host-repository memory.
+
+First-run host scaffold behavior:
+- If any of these files are missing, treat it as first-run and run `./commands/create-host-ai-scaffold.sh` automatically without waiting for user input:
+  - `../AGENTS.md`
+  - `../.ai/MEMORY.md`
+  - `../.ai/RULES.md`
+  - `../.ai/DEBUG.md`
+  - `../.ai/tasks/TODO.md`
+- This scaffold step is idempotent and safe to run multiple times.
+
+After scaffold checks, review these host-repository files when they exist:
 - `../.ai/MEMORY.md`
 - `../.ai/RULES.md`
 - `../.ai/DEBUG.md`


### PR DESCRIPTION
## Summary
Ensure OpenCaw startup auto-runs host scaffold on first run so users do not need to request it manually.

## What changed
- Updated `AGENTS.md` Session startup review instructions to:
  - detect first-run if any key host files are missing
  - run `./commands/create-host-ai-scaffold.sh` automatically without user input
  - continue with normal host file review after scaffold checks
  - document idempotent behavior

## Risks
- Low risk; instruction-only change in baseline guidance.
- Existing sessions may need a fresh start to pick up the updated startup behavior.

## Validation
- Verified host scaffold execution and resulting host bootstrap file at `C:\Repository\AGENTS.md`.
- Attempted `bash ./commands/validate-opencaw.sh`; currently blocked by existing CRLF shebang issues in repository shell scripts (`/usr/bin/env: 'bash\r': No such file or directory`).

## Deployment / rollback notes
- No deployment impact.
- Rollback by reverting commit `30121ca`.
