### PR TITLE
fix(commands): enforce LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
Fix shell-script execution failures caused by CRLF shebang endings (e.g. `/usr/bin/env: 'bash\r': No such file or directory`).

## What changed
- Added `.gitattributes` rule:
  - `*.sh text eol=lf`

This enforces LF line endings for all shell scripts in the repository so shebangs remain portable under Bash environments.

## Risks
- Low risk.
- Existing local clones with already-checked-out CRLF shell scripts may need a one-time refresh/re-checkout of script files after pulling.

## Validation
- `git check-attr text eol -- commands/validate-opencaw.sh` returns `text: set`, `eol: lf`.
- `bash ./commands/validate-opencaw.sh` now runs successfully:
  - Roles validation passed
  - Skills validation passed
  - Commands validation passed
  - Role language/tool alignment validation passed
  - Cloud preference validation passed
  - OpenCaw validation passed

## Deployment / rollback notes
- No deployment impact.
- Rollback by reverting commit `631c7e8`.
