### PR TITLE
fix(tasks): use virtual task paths in issue bodies

### DIFF
--- a/commands/create-task-issue.sh
+++ b/commands/create-task-issue.sh
@@ -21,6 +21,7 @@ opencaw_root="$(cd "$script_dir/.." && pwd)"
 host_root="$(cd "$opencaw_root/.." && pwd)"
 host_tasks_dir="$host_root/.ai/tasks"
 task_file="$host_tasks_dir/$task_name/TASK.md"
+task_virtual_path=".ai/tasks/$task_name/TASK.md"
 open_issues_file="$host_tasks_dir/OPEN_ISSUES.md"
 
 resolve_gh() {
@@ -116,7 +117,7 @@ else
 OpenCaw task issue for \`$task_name\`.
 
 Task file:
-\`$task_file\`
+\`$task_virtual_path\`
 
 Use this issue as the canonical tracker for planning, implementation updates, QA evidence, and closure.
 EOF


### PR DESCRIPTION
## Summary
Fix task issue body generation so task references use virtual paths from repository root onward.

## What changed
- Updated `commands/create-task-issue.sh` to use:
  - `.ai/tasks/<task_name>/TASK.md`
- Removed absolute host path usage from default issue body text.

## Risks
- Low risk.
- Change is scoped to issue body formatting only.

## Validation
- Verified generated/edited issue body now uses:
  - `.ai/tasks/integrate-task-github-issue-tracking/TASK.md`
- Confirmed issue #15 body is corrected.

## Deployment / rollback notes
- No deployment impact.
- Rollback by reverting commit `98aa9d9`.

Closes #15