### PR TITLE
feat(arts): add generative-art-designer role with sanity tooling

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -23,6 +23,7 @@ Current role catalog location:
 
 ### Arts & Visual Design
 - `css-vector-artist`
+- `generative-art-designer`
 
 ### Full Stack
 - `fullstack-engineer`
@@ -66,6 +67,7 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `computer-science/code-migrator`: `code migrator`, `code-migrator`, `codemigrator`, `migration-engineer`, `modernization-engineer`
 - `computer-science/code-reviewer`: `code reviewer`, `code-reviewer`, `codereviewer`
 - `arts/css-vector-artist`: `css-vector-artist`, `css-vector`, `interface-vector-artist`, `logo-vector-artist`, `vector-ui-artist`
+- `arts/generative-art-designer`: `generative-art-designer`, `generative-art`, `ai-image-designer`, `art-iteration-designer`, `image-prompt-designer`
 - `computer-science/data-engineer`: `analytics`, `data`, `data engineer`, `data-engineer`, `dataengineer`
 - `computer-science/database-optimizer`: `analytics`, `data`, `database optimizer`, `database-optimizer`, `databaseoptimizer`
 - `computer-science/devops-automator`: `ci-cd`, `cicd`, `devops`, `devops automator`, `devops-automator`, `devopsautomator`, `platform`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -59,6 +59,17 @@
       "commands/validate-svg-assets.sh"
     ]
   },
+  "arts/generative-art-designer": {
+    "skills": [
+      "generate-art-with-native-tools",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
   "css-vector-artist": {
     "skills": [
       "create-css-vector-art",
@@ -69,6 +80,17 @@
     "commands": [
       "commands/print-css-art-token-template.sh",
       "commands/validate-svg-assets.sh"
+    ]
+  },
+  "generative-art-designer": {
+    "skills": [
+      "generate-art-with-native-tools",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
     ]
   },
   "security-engineer": {

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -88,6 +88,16 @@ Commands:
 - `commands/print-css-art-token-template.sh`
 - `commands/validate-svg-assets.sh`
 
+### arts/generative-art-designer
+Skills:
+- `generate-art-with-native-tools`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
 ### security-engineer
 Skills:
 - `threat-model-analysis`

--- a/.roles/arts/generative-art-designer/ROLE.md
+++ b/.roles/arts/generative-art-designer/ROLE.md
@@ -1,0 +1,59 @@
+---
+name: generative-art-designer
+description: Generative art specialist focused on model-native image creation workflows with iterative sanity checks for safety, text quality, and visual correctness.
+aliases:
+  - generative-art-designer
+  - generative-art
+  - ai-image-designer
+  - art-iteration-designer
+  - image-prompt-designer
+category: arts
+color: red
+vibe: Iterates visual concepts into clean, safe, production-ready outputs.
+---
+
+# Purpose
+
+Design and refine model-generated visual assets using the native art generation capabilities of the active model runtime, with strict sanity and safety gates before acceptance.
+
+# Responsibilities
+
+- Create high-quality visual concepts, compositions, and prompt strategies using model-native image generation tools.
+- Run iterative generation passes until outputs satisfy defined sanity rules.
+- Enforce language rules for rendered text:
+  - default to English text unless the user explicitly specifies another spoken language
+  - when overridden, ensure rendered text matches the user-specified language
+- Reject outputs with anatomy artifacts (for example extra hands or duplicated limbs).
+- Reject outputs with text artifacts (for example unintended duplicated letters or malformed typography).
+- Reject outputs containing nudity.
+- Reject outputs containing graphic violence.
+- Keep a concise iteration record that explains what was adjusted between passes.
+
+# Behavior
+
+- Start with a clear intent brief: subject, style, composition, typography, and constraints.
+- Prefer short iterative loops over one-shot generation: generate, inspect, refine, and re-run.
+- Use a deterministic sanity checklist on every candidate image:
+  - hand/anatomy correctness
+  - text correctness and language compliance
+  - safety compliance (no nudity, no graphic violence)
+- Treat each failed check as a blocking defect and regenerate with targeted corrections.
+- Preserve user intent while applying the strictest interpretation of safety and quality rules.
+- If the user requests non-English text, explicitly acknowledge and enforce that language target in the generation brief.
+
+# Constraints
+
+- Do not accept images with extra hands.
+- Do not accept images with accidental duplicated letters or malformed text artifacts.
+- Do not output non-English text unless the user explicitly overrides the spoken language.
+- Do not produce nude images.
+- Do not produce graphic violence.
+- Do not bypass sanity checks to satisfy speed.
+- Do not claim an image passed checks without explicit verification against the checklist.
+
+# Collaboration
+
+- Partner with `qa-engineer` to formalize and report visual sanity outcomes for releases.
+- Partner with `technical-writer` to document prompt templates and quality/safety checklists.
+- Partner with `frontend-developer` when generated assets must integrate into UI components.
+- Partner with `css-vector-artist` when composition should transition from generated concept art into production vector/CSS assets.

--- a/commands/art-sanity-checklist.sh
+++ b/commands/art-sanity-checklist.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required_language="${1:-english}"
+required_language="$(printf '%s' "$required_language" | tr '[:upper:]' '[:lower:]')"
+
+cat <<EOF
+Art sanity checklist template
+-----------------------------
+Use one report per generated image candidate.
+
+expected_language=${required_language}
+hands_ok=true
+text_double_letters_ok=true
+text_language=${required_language}
+nudity_ok=true
+graphic_violence_ok=true
+notes=
+EOF
+
+echo
+echo "Fail the candidate if any _ok field is not true."
+echo "Default text language is English unless user override is provided."

--- a/commands/validate-art-sanity-report.sh
+++ b/commands/validate-art-sanity-report.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/validate-art-sanity-report.sh "<report_file>" [expected_language]
+EOF
+}
+
+report_file="${1:-}"
+expected_language="${2:-english}"
+
+if [[ -z "$report_file" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -f "$report_file" ]]; then
+  echo "Report file not found: $report_file" >&2
+  exit 1
+fi
+
+normalize() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+get_value() {
+  local key="$1"
+  local line value
+  line="$(grep -Ei "^${key}=" "$report_file" | tail -n1 || true)"
+  value="${line#*=}"
+  normalize "$value"
+}
+
+expected_language="$(normalize "$expected_language")"
+hands_ok="$(get_value 'hands_ok')"
+text_double_letters_ok="$(get_value 'text_double_letters_ok')"
+text_language="$(get_value 'text_language')"
+nudity_ok="$(get_value 'nudity_ok')"
+graphic_violence_ok="$(get_value 'graphic_violence_ok')"
+
+status=0
+
+check_true() {
+  local field="$1"
+  local value="$2"
+  if [[ "$value" != "true" ]]; then
+    echo "FAIL: $field must be true (found: $value)" >&2
+    status=1
+  fi
+}
+
+check_true "hands_ok" "$hands_ok"
+check_true "text_double_letters_ok" "$text_double_letters_ok"
+check_true "nudity_ok" "$nudity_ok"
+check_true "graphic_violence_ok" "$graphic_violence_ok"
+
+if [[ -z "$text_language" ]]; then
+  echo "FAIL: text_language is missing." >&2
+  status=1
+elif [[ "$text_language" != "$expected_language" ]]; then
+  echo "FAIL: text_language mismatch (expected: $expected_language, found: $text_language)" >&2
+  status=1
+fi
+
+if [[ $status -ne 0 ]]; then
+  echo "Art sanity report validation failed." >&2
+  exit 1
+fi
+
+echo "Art sanity report validation passed."
+echo "Language: $text_language"
+echo "Rules: no extra hands, no duplicated text artifacts, no nudity, no graphic violence"

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -46,6 +46,12 @@ Common reusable skills included in OpenCaw by category.
 - `ui-refactor` - Refactor UI code for clarity, reuse, and maintainability.
 - `accessibility-review` - Review UI for accessibility issues and improvements.
 
+## Arts
+
+- `generate-art-with-native-tools` - Generate images with the active model's built-in art tooling.
+- `iterate-art-to-sanity` - Iterate generated images until anatomy, text, language, and safety checks pass.
+- `enforce-art-language-safety` - Enforce text-language policy and core visual safety constraints.
+
 ## Security
 
 - `threat-model-analysis` - Analyze threats, abuse paths, and trust boundaries.

--- a/skills/enforce-art-language-safety/SKILL.md
+++ b/skills/enforce-art-language-safety/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: enforce-art-language-safety
+description: Enforce text language and safety policy for generated images with explicit user-language override handling.
+---
+
+## When to use
+Use when generated images contain text or when content-safety constraints must be explicitly validated.
+
+## Output
+- required language decision (English default or user override)
+- safety compliance verdict
+- regeneration directives for any failing safety or language checks
+
+## Notes
+- Language policy:
+  - default to English text
+  - if the user specifies another spoken language, generated text must match it
+- Safety policy:
+  - no nudity
+  - no graphic violence
+- Combine with iterative sanity checking until compliant.

--- a/skills/generate-art-with-native-tools/SKILL.md
+++ b/skills/generate-art-with-native-tools/SKILL.md
@@ -1,0 +1,17 @@
+---
+name: generate-art-with-native-tools
+description: Create visual assets using the model's built-in image generation tools with clear prompt intent and iterative refinement.
+---
+
+## When to use
+Use when a task requires generating new images, concept art, compositions, or text-bearing visuals directly from model-native art tooling.
+
+## Output
+- generation brief (subject, style, composition, text requirements)
+- iteration log of prompt changes and outcomes
+- selected candidate image(s) for sanity review
+
+## Notes
+- Use the built-in art/image generation capabilities available in the active model runtime.
+- Keep prompts explicit about anatomy quality, typography clarity, and safety constraints.
+- Default text language is English unless the user specifies another language.

--- a/skills/iterate-art-to-sanity/SKILL.md
+++ b/skills/iterate-art-to-sanity/SKILL.md
@@ -1,0 +1,21 @@
+---
+name: iterate-art-to-sanity
+description: Iterate generated images until they pass mandatory sanity rules for anatomy, text quality, language alignment, and safety.
+---
+
+## When to use
+Use when generated images need quality gating before acceptance or delivery.
+
+## Output
+- sanity checklist outcome per image candidate
+- failed checks with targeted prompt corrections
+- final accepted image reference after all checks pass
+
+## Notes
+- Required fail conditions:
+  - extra hands or anatomy artifacts
+  - duplicated/malformed letters in rendered text
+  - text language mismatch vs required language
+  - nudity
+  - graphic violence
+- Continue iterating until all sanity checks pass.


### PR DESCRIPTION
## Summary
Add a new arts role, `arts/generative-art-designer`, focused on model-native image generation with iterative sanity and safety checks.

## What changed
- Added role:
  - `.roles/arts/generative-art-designer/ROLE.md`
- Added skills:
  - `skills/generate-art-with-native-tools/SKILL.md`
  - `skills/iterate-art-to-sanity/SKILL.md`
  - `skills/enforce-art-language-safety/SKILL.md`
- Added commands:
  - `commands/art-sanity-checklist.sh`
  - `commands/validate-art-sanity-report.sh`
- Updated role/skill catalogs and mappings:
  - `.roles/INDEX.md`
  - `.roles/ROLE_SKILL_MAP.md`
  - `.roles/ROLE_SKILL_MAP.json`
  - `skills/INDEX.md`

## Rules enforced by this role
- no extra hands
- no accidental duplicated/malformed letters in text
- default text language is English unless user override
- if user specifies another spoken language, text must match it
- no nude images
- no graphic violence

## Risks
- Low risk, additive role/skill/command changes only.
- No breaking behavior for existing roles.

## Validation
- `bash -n commands/art-sanity-checklist.sh commands/validate-art-sanity-report.sh`
- `bash commands/art-sanity-checklist.sh english`
- `bash commands/validate-art-sanity-report.sh ../.ai/reports/art-sanity-pass.txt english`
- `bash commands/resolve-role.sh generative-art-designer`
- `bash commands/resolve-role.sh arts/generative-art-designer`
- `bash commands/resolve-role.sh ai-image-designer`
- `bash ./commands/validate-opencaw.sh`

## Deployment / rollback notes
- Deployment impact: none (metadata/scripts only).
- Rollback: revert commit `319e8e8`.

Closes #17