### PR TITLE
fix(tasks): preserve TASK.md markdown in issue body

### DIFF
--- a/commands/create-task-issue.sh
+++ b/commands/create-task-issue.sh
@@ -92,6 +92,47 @@ upsert_issue_section() {
   printf '%s\n' "$issue_url" >> "$task_file"
 }
 
+extract_task_markdown() {
+  local source_file="$1"
+  local source_virtual_path="$2"
+
+  if [[ ! -f "$source_file" ]]; then
+    printf '_Task file not found: `%s`._\n' "$source_virtual_path"
+    return
+  fi
+
+  awk -v virtual_path="$source_virtual_path" '
+    BEGIN {
+      in_issue = 0
+      emitted = 0
+    }
+    {
+      gsub(/\r/, "", $0)
+
+      if ($0 ~ /^##[[:space:]]+Issue[[:space:]]*$/) {
+        in_issue = 1
+        next
+      }
+
+      if (in_issue == 1) {
+        if ($0 ~ /^##[[:space:]]+/) {
+          in_issue = 0
+        } else {
+          next
+        }
+      }
+
+      print $0
+      emitted = 1
+    }
+    END {
+      if (emitted == 0) {
+        printf "_No task details found in `%s`._\n", virtual_path
+      }
+    }
+  ' "$source_file"
+}
+
 if [[ -z "$issue_title" ]]; then
   issue_title="Task: $task_name"
 fi
@@ -113,11 +154,16 @@ if [[ -n "$issue_body_file" ]]; then
   fi
   issue_body="$(cat "$issue_body_file")"
 else
+  task_markdown="$(extract_task_markdown "$task_file" "$task_virtual_path")"
   issue_body="$(cat <<EOF
 OpenCaw task issue for \`$task_name\`.
 
 Task file:
 \`$task_virtual_path\`
+
+Task details (from TASK.md):
+
+$task_markdown
 
 Use this issue as the canonical tracker for planning, implementation updates, QA evidence, and closure.
 EOF


### PR DESCRIPTION
## Summary
- Fix task issue creation so the issue body mirrors TASK.md markdown content directly.
- Keep the task file reference as a virtual repo-root path.
- Stop generating synthetic ordered-list lines that made task content look off.

## What Changed
- Replaced ordered-list transformation with raw markdown extraction from ../.ai/tasks/<task>/TASK.md.
- Excluded the ## Issue section from copied content to avoid embedding issue URLs in the issue body.
- Updated default issue body section label to Task details (from TASK.md):.

## Risks
- Very large task files may create large issue bodies.
- Non-standard markdown in TASK.md is now preserved exactly (intended behavior).

## Validation
- ash -n ./commands/create-task-issue.sh
- ./commands/validate-opencaw.sh
- End-to-end smoke validation by creating a temporary task issue and verifying preserved markdown headings and bullets (then closing cleanup issues).

Closes #19
