### PR TITLE
feat: import tasks from GitHub issue numbers

### DIFF
--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -261,6 +261,7 @@
       "commands/lint.sh",
       "commands/format.sh",
       "commands/create-task-issue.sh",
+      "commands/import-task-from-issue.sh",
       "commands/sync-task-issues.sh",
       "commands/link-pr-to-task-issue.sh"
     ]

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -27,6 +27,7 @@ These skills and commands apply to all roles:
 - `commands/lint.sh`
 - `commands/format.sh`
 - `commands/create-task-issue.sh`
+- `commands/import-task-from-issue.sh`
 - `commands/sync-task-issues.sh`
 - `commands/link-pr-to-task-issue.sh`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,12 @@ When multiple roles are requested:
 9. Capture lessons: update `../.ai/MEMORY.md` after corrections or durable discoveries
 10. Before final handoff for substantial work, run `clean-context` to compress completed context and refresh high-signal summaries
 
+## Issue-first task import
+- If the user prompt includes an issue reference (for example `Work on #123`), import that issue into task tracking first with `./commands/import-task-from-issue.sh "#123"`.
+- Accept issue references as `#123`, `123`, or a full GitHub issue URL.
+- Reuse the existing task file when the issue is already linked.
+- Keep imported issue URLs in `../.ai/tasks/OPEN_ISSUES.md` only while the issue state is open.
+
 ## Task file rules
 - `../.ai/tasks/TODO.md` is the active ordered checklist only
 - Items should be numbered and ordered by execution sequence

--- a/README.md
+++ b/README.md
@@ -147,6 +147,10 @@ use role devops-engineer and create a CI/CD pipeline as a github action for gcp 
 use role fullstack-engineer and build a calculator app with a simple UI, basic arithmetic operations, tests, task tracking, architecture generation if missing, and final verification
 ```
 
+```text
+work on #123 and implement the fix with tests and verification evidence
+```
+
 ## What happens?
 
 OpenCaw deterministically resolves your prompt into:
@@ -166,9 +170,9 @@ To be more specific it will:
 3. if missing, ask which architecture templates apply
 4. generate `ARCHITECTURE.md`
 5. update `.ai/tasks/TODO.md` with an ordered checklist
-6. create a task file such as:
+6. create or import a task file such as:
    - `.ai/tasks/create-calculator-app/TASK.md`
-7. create/link a matching GitHub issue and add the URL to `.ai/tasks/OPEN_ISSUES.md`
+7. create/link a matching GitHub issue, or import an existing one from a prompt like `Work on #123`, and add the URL to `.ai/tasks/OPEN_ISSUES.md`
 8. apply appropriate skills such as:
    - `plan-task`
    - `feature-end-to-end`
@@ -477,6 +481,7 @@ Rules:
 - `TODO.md` contains the ordered list of tasks
 - Each task folder contains a detailed `TASK.md`
 - Each substantial task is backed by one GitHub issue
+- Existing GitHub issues can be imported directly with `./commands/import-task-from-issue.sh "<issue-ref>"` where `<issue-ref>` can be `#123`, `123`, or a full issue URL
 - Track only open issue URLs (one per line) in `OPEN_ISSUES.md`
 - Sync and remove closed issue URLs from `.ai/tasks` tracking
 - Agents update progress as tasks are completed
@@ -611,6 +616,7 @@ run command dotnet-build
 | `dotnet-test.sh` | Run tests |
 | `run-tests.sh` | Run repo tests |
 | `create-task-issue.sh` | Create/link a GitHub issue for a task and track its URL |
+| `import-task-from-issue.sh` | Import a task from an existing GitHub issue number/URL and link tracking files |
 | `sync-task-issues.sh` | Remove closed issue URLs from active `.ai/tasks` tracking |
 | `link-pr-to-task-issue.sh` | Add issue-closing linkage to PR body |
 | `comment-issue-test-results.sh` | Post QA/Playwright results and screenshot references to issue |

--- a/commands/import-task-from-issue.sh
+++ b/commands/import-task-from-issue.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/import-task-from-issue.sh "<issue_url_or_number_or_#number>" [task_name]
+
+Examples:
+  ./commands/import-task-from-issue.sh "#123"
+  ./commands/import-task-from-issue.sh "123"
+  ./commands/import-task-from-issue.sh "https://github.com/org/repo/issues/123"
+  ./commands/import-task-from-issue.sh "#123" "implement-auth-timeout"
+EOF
+}
+
+issue_ref="${1:-}"
+task_name_input="${2:-}"
+
+if [[ "$issue_ref" == "-h" || "$issue_ref" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ -z "$issue_ref" ]]; then
+  usage >&2
+  exit 1
+fi
+
+resolve_gh() {
+  if command -v gh >/dev/null 2>&1; then
+    GH_BIN="$(command -v gh)"
+    return
+  fi
+
+  if command -v gh.exe >/dev/null 2>&1; then
+    GH_BIN="$(command -v gh.exe)"
+    return
+  fi
+
+  echo "GitHub CLI (gh) is required to import issue tasks." >&2
+  exit 1
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+opencaw_root="$(cd "$script_dir/.." && pwd)"
+host_root="$(cd "$opencaw_root/.." && pwd)"
+host_tasks_dir="$host_root/.ai/tasks"
+open_issues_file="$host_tasks_dir/OPEN_ISSUES.md"
+
+detect_repo_root() {
+  if git -C "$host_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf '%s\n' "$host_root"
+    return
+  fi
+
+  if git -C "$opencaw_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    printf '%s\n' "$opencaw_root"
+    return
+  fi
+
+  echo "Unable to detect a git repository root for issue import." >&2
+  exit 1
+}
+
+normalize_task_name() {
+  local value="$1"
+  value="${value//$'\r'/}"
+  value="$(printf '%s' "$value" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  printf '%s' "$value"
+}
+
+add_open_issue_url() {
+  local issue_url="$1"
+
+  mkdir -p "$host_tasks_dir"
+  touch "$open_issues_file"
+
+  if ! grep -Fxq "$issue_url" "$open_issues_file"; then
+    printf '%s\n' "$issue_url" >> "$open_issues_file"
+  fi
+}
+
+remove_open_issue_url() {
+  local issue_url="$1"
+  local tmp
+
+  [[ -f "$open_issues_file" ]] || return 0
+
+  tmp="$(mktemp)"
+  awk -v url="$issue_url" '$0 != url { print }' "$open_issues_file" > "$tmp"
+  mv "$tmp" "$open_issues_file"
+}
+
+find_task_for_issue_url() {
+  local issue_url="$1"
+  local task_md
+
+  [[ -d "$host_tasks_dir" ]] || return 1
+
+  while IFS= read -r -d '' task_md; do
+    if grep -Fq "$issue_url" "$task_md"; then
+      printf '%s\n' "$task_md"
+      return 0
+    fi
+  done < <(find "$host_tasks_dir" -mindepth 2 -maxdepth 2 -name TASK.md -print0)
+
+  return 1
+}
+
+upsert_issue_section() {
+  local task_file="$1"
+  local issue_url="$2"
+
+  [[ -f "$task_file" ]] || return 0
+
+  if grep -Fq "$issue_url" "$task_file"; then
+    return 0
+  fi
+
+  if ! grep -q '^## Issue$' "$task_file"; then
+    printf '\n## Issue\n\n%s\n' "$issue_url" >> "$task_file"
+    return 0
+  fi
+
+  printf '%s\n' "$issue_url" >> "$task_file"
+}
+
+resolve_gh
+repo_root="$(detect_repo_root)"
+
+pushd "$repo_root" >/dev/null
+issue_number="$($GH_BIN issue view "$issue_ref" --json number --jq .number 2>/dev/null || true)"
+if [[ -z "$issue_number" ]]; then
+  popd >/dev/null
+  echo "Unable to resolve GitHub issue from: $issue_ref" >&2
+  exit 1
+fi
+
+issue_title="$($GH_BIN issue view "$issue_ref" --json title --jq .title)"
+issue_body="$($GH_BIN issue view "$issue_ref" --json body --jq .body)"
+issue_url="$($GH_BIN issue view "$issue_ref" --json url --jq .url)"
+issue_state="$($GH_BIN issue view "$issue_ref" --json state --jq .state)"
+popd >/dev/null
+
+existing_task_file="$(find_task_for_issue_url "$issue_url" || true)"
+if [[ -n "$existing_task_file" ]]; then
+  if [[ "$issue_state" == "OPEN" ]]; then
+    add_open_issue_url "$issue_url"
+  else
+    remove_open_issue_url "$issue_url"
+  fi
+
+  echo "Issue already linked: $existing_task_file"
+  echo "$existing_task_file"
+  exit 0
+fi
+
+if [[ -n "$task_name_input" ]]; then
+  task_name="$(normalize_task_name "$task_name_input")"
+else
+  title_slug="$(normalize_task_name "$issue_title")"
+  if [[ -n "$title_slug" ]]; then
+    task_name="issue-${issue_number}-${title_slug}"
+  else
+    task_name="issue-${issue_number}"
+  fi
+fi
+
+if [[ -z "$task_name" ]]; then
+  echo "Could not derive a valid task name from input/issue title." >&2
+  exit 1
+fi
+
+task_dir="$host_tasks_dir/$task_name"
+task_file="$task_dir/TASK.md"
+created=0
+
+mkdir -p "$task_dir"
+
+trimmed_issue_body="$(printf '%s' "$issue_body" | tr -d '\r' | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+if [[ -z "$trimmed_issue_body" ]]; then
+  issue_body="_No issue body provided in GitHub issue._"
+fi
+
+if [[ ! -f "$task_file" ]]; then
+  cat > "$task_file" <<EOF
+# $issue_title
+
+## Goal
+Implement GitHub issue #$issue_number.
+
+## Scope
+- Imported from GitHub issue #$issue_number
+- Issue URL: $issue_url
+- Issue state at import: $issue_state
+
+## Assumptions
+
+## Work Instructions
+$issue_body
+
+## Verification
+
+## Review
+
+## Issue
+$issue_url
+EOF
+  created=1
+else
+  upsert_issue_section "$task_file" "$issue_url"
+fi
+
+if [[ "$issue_state" == "OPEN" ]]; then
+  add_open_issue_url "$issue_url"
+else
+  remove_open_issue_url "$issue_url"
+fi
+
+if [[ $created -eq 1 ]]; then
+  echo "Imported issue #$issue_number into $task_file"
+else
+  echo "Linked issue #$issue_number to existing task file: $task_file"
+fi
+
+echo "$task_file"

--- a/skills/create-task-file/SKILL.md
+++ b/skills/create-task-file/SKILL.md
@@ -14,6 +14,7 @@ Use when a substantial task needs a dedicated instruction file and issue-backed 
 - The default workflow creates or links a matching GitHub issue.
 - Open issue URLs are tracked in `../.ai/tasks/OPEN_ISSUES.md`.
 - Use `--no-issue` only for exceptional local-only work.
+- If the task already exists as a GitHub issue, use `../commands/import-task-from-issue.sh "<issue-ref>"` instead.
 
 ## Command
 ../commands/create-task-file.sh "<unique_task_name>" ["Task Title"] [--no-issue]

--- a/skills/manage-task-issues/SKILL.md
+++ b/skills/manage-task-issues/SKILL.md
@@ -15,6 +15,10 @@ Use when creating task plans, generating task files, or reviewing active task li
 - Prefer one issue per substantial task.
 - Track open issues as URLs only in `.ai/tasks/OPEN_ISSUES.md`.
 - Run sync before planning to prune closed issue URLs.
+- Import issue-backed tasks with `../commands/import-task-from-issue.sh "<issue-ref>"` when users ask to work from an existing issue number.
 
 ## Command
 ../commands/sync-task-issues.sh
+
+## Additional command
+../commands/import-task-from-issue.sh "<issue-ref>" [task_name]


### PR DESCRIPTION
## Summary
Add issue-first task import so prompts like `Work on #123` can map directly into OpenCaw task tracking.

## What changed
- Added `commands/import-task-from-issue.sh` to import from `#123`, `123`, or full issue URL.
- Auto-creates or reuses `.ai/tasks/<task>/TASK.md` and upserts the issue link.
- Keeps `.ai/tasks/OPEN_ISSUES.md` aligned to issue open/closed state.
- Updated `AGENTS.md` with deterministic "Issue-first task import" behavior.
- Updated `README.md` examples and command table.
- Added shared command mapping updates in `.roles/ROLE_SKILL_MAP.md` and `.roles/ROLE_SKILL_MAP.json`.
- Updated related skills docs for task/issue workflows.

## Risks
- Depends on `gh` CLI auth/context when importing issue metadata.
- Task name normalization may produce different slugs than manually chosen names.

## Validation
- `./commands/validate-opencaw.sh`
- `bash -n ./commands/import-task-from-issue.sh`
- `./commands/import-task-from-issue.sh --help`

## Deployment / rollback notes
- No runtime deployment impact (tooling/docs change only).
- Rollback by reverting this PR commit.
