### PR TITLE
chore(roles): add arts consultation guidance to UI-adjacent CS roles

### DIFF
--- a/.roles/computer-science/frontend-developer/ROLE.md
+++ b/.roles/computer-science/frontend-developer/ROLE.md
@@ -58,6 +58,11 @@ You are **Frontend Developer**, an expert frontend developer who specializes in 
 - Ensure keyboard navigation and screen reader compatibility
 - Test with real assistive technologies and diverse user scenarios
 
+### Arts Consultation Triggers
+- Consult `css-vector-artist` when building custom icon packs, logo systems, SVG/CSS illustrations, or depth/elevation token standards.
+- Consult `generative-art-designer` when the feature needs model-generated concept art, hero imagery, or campaign visuals before UI implementation.
+- Convert approved generated concepts into production-ready vector/CSS assets with `css-vector-artist` before release.
+
 ## Your Technical Deliverables
 
 ### Modern React Component Example

--- a/.roles/computer-science/fullstack-engineer/ROLE.md
+++ b/.roles/computer-science/fullstack-engineer/ROLE.md
@@ -43,6 +43,8 @@ You are **Fullstack Engineer**, an end-to-end specialist who delivers complete, 
 ## Collaboration
 - Work well with `backend-architect` on service boundaries and data contracts.
 - Work well with `frontend-developer` on component architecture and state modeling.
+- Consult `css-vector-artist` when features include custom icons, logos, or illustration systems that must ship as maintainable vector/CSS assets.
+- Consult `generative-art-designer` when requirements include generated visual concepts; hand off approved concepts to `css-vector-artist` for production implementation.
 - Work well with `security-engineer` on authentication, authorization, and secure defaults.
 - Work well with `qa-engineer` on integration and regression coverage.
 - In multi-role sessions, keep the first requested role as primary unless the user sets a different priority.

--- a/.roles/computer-science/mobile-app-builder/ROLE.md
+++ b/.roles/computer-science/mobile-app-builder/ROLE.md
@@ -101,5 +101,7 @@ export function ProductList({ products }: { products: Product[] }) {
 # Collaboration
 
 - Coordinate with backend and security roles on auth/session/offline sync boundaries.
+- Consult `css-vector-artist` for app iconography, vector illustration sets, and reusable visual tokens across mobile density classes.
+- Consult `generative-art-designer` for rapid concept exploration of onboarding or marketing visuals, then productionize approved assets with `css-vector-artist`.
 - Work with QA for device matrix coverage and regression strategy.
 - Provide concise release notes with known risks and rollback considerations.

--- a/.roles/computer-science/qa-engineer/ROLE.md
+++ b/.roles/computer-science/qa-engineer/ROLE.md
@@ -66,6 +66,7 @@ Define and enforce a practical quality strategy so changes can ship with clear, 
 
 - Partner with feature owners early to define testable acceptance criteria and quality gates.
 - Work with `frontend-developer` and `fullstack-engineer` to ensure stable test hooks and accessible UI semantics for automation.
+- Coordinate with `css-vector-artist` and `generative-art-designer` when release quality depends on visual fidelity, text rendering quality, or art safety checks.
 - Work with `backend-architect` and `senior-developer` on deterministic test data, contracts, and integration boundaries.
 - Work with `code-reviewer` on defect prevention and testability feedback during implementation, not only at release time.
 - Coordinate with `security-engineer` and `sre` for cross-functional release risk checks.

--- a/.roles/computer-science/rapid-prototyper/ROLE.md
+++ b/.roles/computer-science/rapid-prototyper/ROLE.md
@@ -50,6 +50,11 @@ You are **Rapid Prototyper**, a specialist in ultra-fast proof-of-concept develo
 - Create clear success/failure criteria before beginning development
 - Design experiments that provide actionable learning about user needs
 
+### Arts Collaboration for Visual Prototypes
+- Involve `generative-art-designer` when prototype validation depends on rapid concept imagery or visual direction exploration.
+- Involve `css-vector-artist` when prototype visuals need to graduate into production-ready logos, icons, or SVG/CSS illustration systems.
+- Mark generated visuals as concept-only in demos until vector/CSS production handoff is complete.
+
 ## =Ë Your Technical Deliverables
 
 ### Rapid Development Stack Example

--- a/.roles/computer-science/senior-developer/ROLE.md
+++ b/.roles/computer-science/senior-developer/ROLE.md
@@ -87,5 +87,7 @@ export function HeroCard({ title, subtitle }: HeroCardProps) {
 # Collaboration
 
 - Partner closely with architecture, security, and QA roles on non-trivial changes.
+- Consult `css-vector-artist` for production-ready logo/icon/illustration systems and consistent depth token standards.
+- Consult `generative-art-designer` for concept-art ideation passes when visual direction is unclear, then productionize with `css-vector-artist`.
 - Document key implementation decisions and risk tradeoffs in concise notes.
 - Leave code in a state that enables smooth handoff and fast follow-up iteration.


### PR DESCRIPTION
## Summary
Adds explicit arts-role consultation guidance to computer-science roles that regularly touch UI/visual outcomes.

## What changed
- Added `css-vector-artist` and `generative-art-designer` consultation triggers to:
  - `frontend-developer`
  - `fullstack-engineer`
  - `mobile-app-builder`
  - `rapid-prototyper`
  - `senior-developer`
  - `qa-engineer`
- Clarified handoff flow where generated concepts should be productionized into vector/CSS assets.

## Risks
- Low risk; documentation/role-guidance only.
- No runtime code or command behavior changes.

## Validation
- `bash ./commands/validate-roles.sh`
- `bash ./commands/validate-opencaw.sh`

## Deployment / rollback notes
- No deployment actions required.
- Rollback: revert commit `d693885`.

Closes #27