### PR TITLE
feat: add SignalR/WebSockets architecture with SignalR-first guidance

### DIFF
--- a/.architecture/INDEX.md
+++ b/.architecture/INDEX.md
@@ -23,6 +23,7 @@ Available templates in this OpenCaw baseline:
 - POSTGRESDB
 - PYTHON
 - REACT
+- SIGNALR_WEBSOCKETS
 - SOLIDITY
 - SPA
 - SQLITE

--- a/.architecture/LANGUAGE_SUPPORT.md
+++ b/.architecture/LANGUAGE_SUPPORT.md
@@ -22,6 +22,7 @@ For implementation work, prefer this order unless the role cannot reasonably use
 | ANGULAR | TypeScript, JavaScript |
 | VUE | JavaScript, TypeScript |
 | SPA | JavaScript, TypeScript |
+| SIGNALR_WEBSOCKETS | C#, JavaScript, TypeScript |
 | PYTHON | Python |
 | SOLIDITY | Solidity, TypeScript (tooling/scripts) |
 | MSSQL | SQL, T-SQL |

--- a/.architecture/SIGNALR_WEBSOCKETS.md
+++ b/.architecture/SIGNALR_WEBSOCKETS.md
@@ -1,0 +1,114 @@
+# SIGNALR_WEBSOCKETS.md
+
+This repository follows a **SignalR/WebSockets architecture** focused on reliable real-time messaging, controlled connection lifecycle behavior, and explicit scalability boundaries.
+
+The architecture is optimized for:
+
+- server-to-client push updates
+- bidirectional low-latency communication
+- connection-state awareness
+- scale-out friendly messaging patterns
+
+The goal is to keep the system:
+
+- resilient under connection churn
+- explicit about delivery guarantees
+- secure at connection and message boundaries
+- operationally observable
+
+---
+
+# Core Architecture Rule
+
+**Favor SignalR when available; use raw WebSockets only when protocol-level control is explicitly required.**
+
+Prefer:
+
+```text
+Application events -> SignalR Hub contracts -> supported transports (WebSockets when available)
+```
+
+Use raw WebSockets only when:
+
+- SignalR protocol/features are insufficient for the use case
+- custom framing/subprotocol behavior is required
+- there is a documented reason to bypass SignalR abstractions
+
+---
+
+# Transport and Protocol Rules
+
+- treat WebSockets as a transport, not an architecture on its own
+- allow transport fallback behavior when using SignalR unless strict WebSocket-only behavior is required
+- define message contract versioning for client/server compatibility
+- keep payload formats explicit and bounded
+
+---
+
+# Hub and Boundary Rules
+
+- keep SignalR hubs thin and focused on real-time orchestration
+- move business rules into application/domain layers
+- define explicit hub method contracts per feature area
+- avoid leaking persistence or infrastructure concerns directly into hubs
+
+---
+
+# Connection Lifecycle Rules
+
+- define connect/disconnect/reconnect behavior explicitly
+- do not rely on in-memory connection identity as durable state
+- externalize user/session mapping when required beyond single-instance runtime
+- implement timeout and heartbeat expectations for long-lived sessions
+
+---
+
+# Scaling and Delivery Rules
+
+- plan for horizontal scale from the start (for example Azure SignalR Service or Redis backplane)
+- define ordering expectations per message stream
+- design idempotent client handlers for duplicate delivery scenarios
+- avoid assuming exactly-once semantics over real-time channels
+
+---
+
+# Security Rules
+
+- authenticate and authorize at connection and method boundaries
+- validate group/channel membership server-side
+- apply least privilege for publish/subscribe capabilities
+- avoid sending sensitive data without explicit encryption and retention policy consideration
+
+---
+
+# Observability and Operations
+
+- log connection counts, reconnect rates, and error categories
+- monitor hub invocation latency and message throughput
+- instrument dropped connection and backpressure scenarios
+- document deployment impact for scale unit or backplane changes
+
+---
+
+# Testing Strategy
+
+- unit test hub orchestration and contract validation paths
+- integration test connect/reconnect and group membership behavior
+- load test concurrent connection and fan-out scenarios
+- validate client backward compatibility for contract evolution
+
+---
+
+# Anti-Patterns
+
+Never introduce:
+
+- business logic concentrated inside hubs or WebSocket handlers
+- hard dependency on single-node in-memory connection state
+- undocumented message schemas for critical client workflows
+- assumption that WebSocket availability is guaranteed in every environment
+
+When in doubt:
+
+**Use SignalR abstractions first, and narrow down to raw WebSockets only with explicit technical justification.**
+

--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Example supported frameworks include:
 - ANGULAR
 - VUE
 - AZURE
+- SIGNALR_WEBSOCKETS
 - MSSQL
 - MYSQL
 - POSTGRESDB


### PR DESCRIPTION
## Summary
Add a dedicated real-time architecture template for SignalR/WebSockets with explicit SignalR-first guidance.

## What changed
- Added new architecture template:
  - `.architecture/SIGNALR_WEBSOCKETS.md`
- Updated architecture catalog and docs:
  - `.architecture/INDEX.md`
  - `.architecture/LANGUAGE_SUPPORT.md`
  - `README.md`

## Design intent
- Favor SignalR when available.
- Use raw WebSockets only when protocol-level control is explicitly required.
- Keep hubs/real-time endpoints thin and move business logic inward.
- Make connection lifecycle, scale-out, security, and observability expectations explicit.

## Risks
- Documentation-only baseline update; no runtime code changes.
- Main risk is interpretation drift if teams ignore the SignalR-first rule, which is now explicit in the template.

## Validation
- `bash ./commands/validate-opencaw.sh`

Passed.

## Deployment / rollback notes
- No deployment impact.
- Rollback by reverting this PR.

Closes #33
