### PR TITLE
feat: make architecture generation link-based by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,8 @@ Frameworks are located in:
 
 These frameworks allow AI agents to generate a unified `ARCHITECTURE.md` file for a repository by combining multiple architecture standards.
 
+By default, generation is link-based so `ARCHITECTURE.md` stays concise and references selected template files in `./.architecture/`. Use inline generation only when full embedded content is explicitly required.
+
 Example supported frameworks include:
 
 - DOTNET
@@ -675,4 +677,3 @@ Then:
 | Command | Execution |
 
 ---
-

--- a/commands/generate-architecture.sh
+++ b/commands/generate-architecture.sh
@@ -1,12 +1,69 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -eq 0 ]]; then
-  echo 'Usage: ./commands/generate-architecture.sh "<TEMPLATE1>" ["TEMPLATE2" ...]'
+usage() {
+  cat <<'EOF'
+Usage: ./commands/generate-architecture.sh [--inline] "<TEMPLATE1>" ["TEMPLATE2" ...]
+
+Defaults to concise link-based output in ../ARCHITECTURE.md.
+Use --inline to embed full template contents.
+EOF
+}
+
+mode='link'
+templates=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inline)
+      mode='inline'
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        templates+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      templates+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#templates[@]}" -eq 0 ]]; then
+  usage >&2
   exit 1
 fi
 
-arch_target="../ARCHITECTURE.md"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+opencaw_root="$(cd "$script_dir/.." && pwd)"
+host_root="$(cd "$opencaw_root/.." && pwd)"
+mount_dir_name="$(basename "$opencaw_root")"
+mount_path_from_host="./${mount_dir_name}"
+arch_target="$host_root/ARCHITECTURE.md"
+
+selected=()
+for name in "${templates[@]}"; do
+  upper_name="${name^^}"
+  template_path="$opencaw_root/.architecture/${upper_name}.md"
+  if [[ ! -f "$template_path" ]]; then
+    echo "Missing architecture template: $template_path" >&2
+    exit 1
+  fi
+  selected+=("$upper_name")
+done
 
 {
   echo "# ARCHITECTURE.md"
@@ -14,27 +71,43 @@ arch_target="../ARCHITECTURE.md"
   echo "This file is the canonical architecture contract for this repository."
   echo
   echo "Generated from OpenCaw architecture templates:"
-  for name in "$@"; do
-    echo "- ${name^^}"
+  for name in "${selected[@]}"; do
+    echo "- $name"
   done
   echo
   echo "---"
   echo
-  for name in "$@"; do
-    template="./.architecture/${name^^}.md"
-    if [[ ! -f "$template" ]]; then
-      echo "Missing architecture template: $template" >&2
-      exit 1
-    fi
-    echo "<!-- BEGIN TEMPLATE: ${name^^} -->"
+
+  if [[ "$mode" == 'link' ]]; then
+    echo "This document intentionally stays concise by linking selected templates."
     echo
-    cat "$template"
+    echo "## Selected Template Links"
     echo
-    echo "<!-- END TEMPLATE: ${name^^} -->"
+    for name in "${selected[@]}"; do
+      echo "- [$name](${mount_path_from_host}/.architecture/${name}.md)"
+    done
     echo
-    echo "---"
+    echo "Use the linked template files as the authoritative architecture details."
+  else
+    echo "## Inlined Templates"
     echo
-  done
+    for name in "${selected[@]}"; do
+      template_path="$opencaw_root/.architecture/${name}.md"
+      echo "<!-- BEGIN TEMPLATE: ${name} -->"
+      echo
+      cat "$template_path"
+      echo
+      echo "<!-- END TEMPLATE: ${name} -->"
+      echo
+      echo "---"
+      echo
+    done
+  fi
 } > "$arch_target"
 
 echo "Wrote $arch_target"
+if [[ "$mode" == 'link' ]]; then
+  echo "Mode: link (default)."
+else
+  echo "Mode: inline."
+fi

--- a/skills/generate-architecture/SKILL.md
+++ b/skills/generate-architecture/SKILL.md
@@ -10,8 +10,10 @@ Use when `../ARCHITECTURE.md` is missing or when the user wants to regenerate it
 1. If `../ARCHITECTURE.md` is missing and `../.ai/` is also missing, ask the user which templates from `./.architecture/` apply.
 2. Support multiple templates for mixed-stack repositories.
 3. Save the selected template names to `../.ai/`.
-4. Generate `../ARCHITECTURE.md` from the selected templates.
-5. Treat `../ARCHITECTURE.md` as the authoritative architecture contract afterward.
+4. Generate `../ARCHITECTURE.md` from the selected templates using concise links by default (to avoid oversized files).
+5. Use inline mode only when the user explicitly asks for fully embedded template content.
+6. Treat `../ARCHITECTURE.md` as the authoritative architecture contract afterward.
 
 ## Commands
 - `./commands/generate-architecture.sh "<TEMPLATE1>" ["TEMPLATE2" ...]`
+- `./commands/generate-architecture.sh --inline "<TEMPLATE1>" ["TEMPLATE2" ...]`


### PR DESCRIPTION
## Summary
Change architecture generation to produce a concise link-based `ARCHITECTURE.md` by default, so selecting multiple templates does not create an oversized file.

## What changed
- Updated `commands/generate-architecture.sh`:
  - default mode now writes links to selected templates
  - added optional `--inline` mode for full embedded template output
  - validates selected templates and resolves host-relative OpenCaw template links
- Updated `skills/generate-architecture/SKILL.md` to document link-first behavior and inline fallback.
- Updated `README.md` architecture generation guidance.

## Risks
- Generated links assume OpenCaw remains mounted at a stable path (for example `.codex`, `.cursor`, `.claude`, or repo mount path).
- Teams expecting fully inlined architecture contracts must now explicitly use `--inline`.

## Validation
- `bash ./commands/validate-opencaw.sh`

Passed.

## Deployment / rollback notes
- No runtime deployment impact (generator/documentation behavior only).
- Rollback by reverting this PR.

Closes #35
