### PR TITLE
fix: use read directives for ARCHITECTURE generation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,12 +59,14 @@ Architecture templates live in:
 ### When `../ARCHITECTURE.md` is missing
 - Ask the user which architecture templates in `./.architecture/` apply to the repository.
 - Support selecting multiple templates for multi-architecture repositories.
-- After the user answers, generate `../ARCHITECTURE.md` by composing the selected templates.
+- After the user answers, generate `../ARCHITECTURE.md` with `./commands/generate-architecture.sh "<TEMPLATE1>" ["TEMPLATE2" ...]`.
+- Default generation must use concise read directives (for example `Read \`./<mount>/.architecture/DOTNET.md\` instructions`) instead of inlining template text.
+- Use `--inline` only when the user explicitly asks for fully embedded template content.
 - Once generated, use `../ARCHITECTURE.md` as the authoritative architecture contract.
 
 ### When regenerating architecture later
 - Ask the user again which templates apply.
-- Regenerate `../ARCHITECTURE.md` from the selected templates.
+- Regenerate `../ARCHITECTURE.md` with the same default read-directive mode unless inline output is explicitly requested.
 
 ## Role casting
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Frameworks are located in:
 
 These frameworks allow AI agents to generate a unified `ARCHITECTURE.md` file for a repository by combining multiple architecture standards.
 
-By default, generation is link-based so `ARCHITECTURE.md` stays concise and references selected template files in `./.architecture/`. Use inline generation only when full embedded content is explicitly required.
+By default, generation is read-reference based so `ARCHITECTURE.md` stays concise and contains directives such as `Read \`./<mount>/.architecture/DOTNET.md\` instructions`. Use inline generation only when full embedded content is explicitly required.
 
 Example supported frameworks include:
 

--- a/commands/generate-architecture.sh
+++ b/commands/generate-architecture.sh
@@ -56,7 +56,9 @@ arch_target="$host_root/ARCHITECTURE.md"
 
 selected=()
 for name in "${templates[@]}"; do
-  upper_name="${name^^}"
+  normalized_name="${name//-/_}"
+  normalized_name="${normalized_name// /_}"
+  upper_name="${normalized_name^^}"
   template_path="$opencaw_root/.architecture/${upper_name}.md"
   if [[ ! -f "$template_path" ]]; then
     echo "Missing architecture template: $template_path" >&2
@@ -79,15 +81,15 @@ done
   echo
 
   if [[ "$mode" == 'link' ]]; then
-    echo "This document intentionally stays concise by linking selected templates."
+    echo "This document intentionally stays concise by referencing selected templates."
     echo
-    echo "## Selected Template Links"
+    echo "## Read Template Instructions"
     echo
     for name in "${selected[@]}"; do
-      echo "- [$name](${mount_path_from_host}/.architecture/${name}.md)"
+      echo "Read \`${mount_path_from_host}/.architecture/${name}.md\` instructions"
     done
     echo
-    echo "Use the linked template files as the authoritative architecture details."
+    echo "Add repository-specific architecture instructions below these read directives."
   else
     echo "## Inlined Templates"
     echo

--- a/skills/generate-architecture/SKILL.md
+++ b/skills/generate-architecture/SKILL.md
@@ -10,7 +10,7 @@ Use when `../ARCHITECTURE.md` is missing or when the user wants to regenerate it
 1. If `../ARCHITECTURE.md` is missing and `../.ai/` is also missing, ask the user which templates from `./.architecture/` apply.
 2. Support multiple templates for mixed-stack repositories.
 3. Save the selected template names to `../.ai/`.
-4. Generate `../ARCHITECTURE.md` from the selected templates using concise links by default (to avoid oversized files).
+4. Generate `../ARCHITECTURE.md` from the selected templates using concise read directives by default (for example `Read \`./<mount>/.architecture/DOTNET.md\` instructions`) to avoid oversized files.
 5. Use inline mode only when the user explicitly asks for fully embedded template content.
 6. Treat `../ARCHITECTURE.md` as the authoritative architecture contract afterward.
 


### PR DESCRIPTION
﻿## Summary
Fix the `ARCHITECTURE.md` creation flow so default generation produces concise read directives instead of embedded template text.

## What changed
- Updated `commands/generate-architecture.sh` link mode output to emit lines like:
  - `Read `{mount}/.architecture/DOTNET.md` instructions`
- Kept inline output available only via explicit `--inline` usage.
- Added template-name normalization in the generator for `-` and space variants (for example `dotnet-aspire` and `dotnet aspire`).
- Updated `AGENTS.md`, `skills/generate-architecture/SKILL.md`, and `README.md` so process guidance matches the default read-directive behavior.

## Risks
- Low risk; command and documentation behavior only.

## Validation
- `bash ./commands/generate-architecture.sh DOTNET AZURE NODE MSSQL MICROSERVICES MAUI EVENT_DRIVEN`
- Verified generated `../ARCHITECTURE.md` now contains `Read `...` instructions` entries.
- `bash ./commands/validate-opencaw.sh` (pass)

## Deployment / rollback notes
- No deployment impact.
- Roll back by reverting commit `3ea5693` if needed.
