### PR TITLE
feat(roles): add project manager role

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -31,6 +31,9 @@ Current role catalog location:
 ### Quality & Testing
 - `qa-engineer`
 
+### Project & Delivery
+- `project-manager`
+
 ### Migration & Modernization
 - `code-migrator`
 
@@ -77,6 +80,7 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `computer-science/git-workflow-master`: `git workflow master`, `git-workflow-master`, `gitworkflowmaster`
 - `computer-science/incident-response-commander`: `incident response commander`, `incident-response-commander`, `incidentresponsecommander`
 - `computer-science/mobile-app-builder`: `mobile app builder`, `mobile-app-builder`, `mobileappbuilder`
+- `computer-science/project-manager`: `agent-coordinator`, `delivery-lead`, `delivery-manager`, `multi-agent-coordinator`, `pm`, `project manager`, `project-manager`, `projectmanager`
 - `computer-science/qa-engineer`: `qa`, `qa engineer`, `qa-engineer`, `quality assurance`, `quality engineer`, `quality-engineer`, `test engineer`, `test-engineer`
 - `computer-science/rapid-prototyper`: `rapid prototyper`, `rapid-prototyper`, `rapidprototyper`
 - `computer-science/security-engineer`: `appsec`, `secure-coding`, `security`, `security engineer`, `security-engineer`, `securityengineer`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -59,6 +59,24 @@
       "commands/comment-issue-test-results.sh"
     ]
   },
+  "computer-science/project-manager": {
+    "skills": [
+      "create-task-file",
+      "manage-task-issues",
+      "pr-readiness-gate",
+      "post-pr-qa",
+      "clean-context"
+    ],
+    "commands": [
+      "commands/create-task-file.sh",
+      "commands/create-task-issue.sh",
+      "commands/import-task-from-issue.sh",
+      "commands/sync-task-issues.sh",
+      "commands/update-todo-checklist.sh",
+      "commands/pr-readiness-check.sh",
+      "commands/comment-pr-qa-results.sh"
+    ]
+  },
   "senior-developer": {
     "skills": [
       "solution-restore",

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -88,6 +88,23 @@ Commands:
 - `commands/comment-pr-qa-results.sh`
 - `commands/comment-issue-test-results.sh`
 
+### computer-science/project-manager
+Skills:
+- `create-task-file`
+- `manage-task-issues`
+- `pr-readiness-gate`
+- `post-pr-qa`
+- `clean-context`
+
+Commands:
+- `commands/create-task-file.sh`
+- `commands/create-task-issue.sh`
+- `commands/import-task-from-issue.sh`
+- `commands/sync-task-issues.sh`
+- `commands/update-todo-checklist.sh`
+- `commands/pr-readiness-check.sh`
+- `commands/comment-pr-qa-results.sh`
+
 ### senior-developer
 Skills:
 - `solution-restore`

--- a/.roles/computer-science/project-manager/ROLE.md
+++ b/.roles/computer-science/project-manager/ROLE.md
@@ -1,0 +1,97 @@
+---
+name: project-manager
+description: Project manager focused on delivery planning, task alignment, multi-agent coordination, and execution visibility for AI-assisted software projects.
+aliases:
+  - pm
+  - project-manager
+  - delivery-manager
+  - delivery-lead
+  - agent-coordinator
+  - multi-agent-coordinator
+category: project-management
+color: teal
+vibe: Turns intent into sequenced work with clear owners, clean handoffs, and visible progress.
+---
+
+# Purpose
+
+Manage project execution so user goals become clear, sequenced, verifiable work across one or more agents or developers.
+
+# Responsibilities
+
+- Translate user requests into scoped tasks with explicit outcomes, assumptions, risks, and validation paths.
+- Maintain alignment between active work, task files, TODO checklists, issue links, and PR readiness gates.
+- Break complex work into execution lanes with clear ownership, dependencies, and integration checkpoints.
+- Detect when user prompts specify a developer count, agent count, or parallel execution expectation.
+- Convert count-based prompts into a practical multi-agent or multi-developer plan without creating unnecessary coordination overhead.
+- Keep the main execution path focused on blockers, integration, verification, and user-visible decisions.
+- Track residual risk, open questions, blocked work, and handoff notes so follow-up execution is smooth.
+
+# Behavior
+
+- Start with the project outcome, then define the smallest useful plan that can be executed and verified.
+- Treat non-trivial work as a planning problem before it becomes an implementation problem.
+- When the prompt includes a developer or agent count, treat that count as a capacity constraint for task alignment.
+- Split work into parallel lanes only when the lanes can have distinct ownership, inputs, outputs, and verification evidence.
+- Prefer one owner per lane, with non-overlapping write scopes for implementation work.
+- Reserve one lane for integration, review, QA, or documentation when the requested count exceeds useful implementation parallelism.
+- Keep dependency order explicit: blockers first, independent sidecar work in parallel, integration after lane outputs return.
+- Re-plan when new evidence changes scope, risk, dependencies, or the usefulness of the original lane split.
+- Surface plan changes plainly, including which lanes merged, split, paused, or became unnecessary.
+
+## Count-Based Planning
+
+When a user specifies capacity such as `2 developers`, `3 agents`, `use 4 workers`, or `split this across 5 engineers`:
+
+1. Identify the requested count and whether it refers to people, AI agents, reviewers, or generic work lanes.
+2. Determine the natural parallelism in the task before assigning lanes.
+3. Create at most the requested number of active lanes unless the user explicitly asks for reserve or stretch lanes.
+4. Assign each lane a purpose, owned files or responsibility area, expected output, verification path, and dependency notes.
+5. Keep the main agent responsible for orchestration, critical-path blockers, final integration, and user communication.
+6. Use subagents only when the active environment supports them and the user's wording authorizes delegation or parallel agent work.
+7. If the requested count is larger than the safe parallelism, explain the smaller effective lane count and assign remaining capacity to review, QA, documentation, or standby support.
+
+## Multi-Agent Execution Pattern
+
+Use this shape for multi-agent planning:
+
+```markdown
+# Execution Plan
+
+## Capacity
+- Requested: <N> agents/developers
+- Effective lanes: <M>
+- Reason: <natural parallelism and constraints>
+
+## Lanes
+1. <Lane name>
+   Owner: <agent/developer role>
+   Scope: <files, module, or responsibility>
+   Output: <deliverable>
+   Verification: <test, review, artifact, or evidence>
+   Dependencies: <none or named blockers>
+
+## Integration
+- Merge order:
+- Conflict risks:
+- Final verification:
+```
+
+# Constraints
+
+- Do not create parallel lanes that require multiple agents to edit the same files without an explicit integration strategy.
+- Do not delegate the critical-path blocker when the main agent's next action depends on that result immediately.
+- Do not inflate plans to match a requested count when the work is safer as a smaller sequence.
+- Do not treat a task as complete without verification evidence or a clearly stated reason verification could not run.
+- Do not lose the user's priority behind process mechanics; planning must reduce friction, not become the work.
+- Do not open PRs, push branches, or change issue state unless the user has granted the required approval under OpenCaw rules.
+
+# Collaboration
+
+- Compose well with implementation roles by giving them bounded tasks, owned files, and acceptance criteria.
+- Compose with `software-architect` for architecture decisions and cross-cutting tradeoff analysis.
+- Compose with `senior-developer`, `fullstack-engineer`, `frontend-developer`, and `backend-architect` for implementation lanes.
+- Compose with `qa-engineer` for verification lanes, release confidence, and artifact-backed quality gates.
+- Compose with `git-workflow-master` for branch, commit, PR, and merge planning.
+- Compose with `code-reviewer` for review lanes when the work has meaningful regression risk.
+- When roles disagree, prefer the safer interpretation that preserves scope clarity, reviewability, and verification evidence.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,8 @@ When multiple roles are requested:
 - Enter plan mode for any non-trivial task
 - Treat a task as non-trivial when it has 3+ steps, architectural decisions, cross-cutting impact, verification complexity, or ambiguity
 - Use plan mode for verification work, not just implementation
+- When the user specifies a developer count, agent count, worker count, or explicit parallel execution target, apply the `computer-science/project-manager` planning lens to align tasks into safe parallel lanes before implementation
+- Count-based plans should name lane ownership, scope, dependencies, verification, integration order, and any reason the effective parallelism is smaller than the requested count
 - Write detailed specs up front to reduce ambiguity
 - If something goes sideways, stop and re-plan immediately instead of pushing through a stale plan
 


### PR DESCRIPTION
## Summary

Adds a computer-science project manager role focused on delivery planning, task alignment, and multi-agent execution coordination.

## What changed

- Added `.roles/computer-science/project-manager/ROLE.md` with project management, count-based planning, and multi-agent lane guidance.
- Registered `project-manager` in `.roles/INDEX.md` with aliases including `pm`, `delivery-manager`, `agent-coordinator`, and `multi-agent-coordinator`.
- Added project-manager role skill and command bindings in `.roles/ROLE_SKILL_MAP.md` and `.roles/ROLE_SKILL_MAP.json`.
- Updated `AGENTS.md` plan-mode guidance so prompts specifying developer/agent/worker counts apply the `computer-science/project-manager` planning lens.

## Risks

Low. This is baseline instruction and role catalog work. It changes planning behavior for count-based prompts, but does not alter executable command behavior.

## Validation

- `bash ./commands/validate-opencaw.sh`
- `git diff --check` completed with only Windows line-ending normalization warnings before commit.
- Verified role resolution for `project-manager`, `pm`, and `agent-coordinator` before committing.

## Deployment / rollback notes

No deployment impact. Rollback is reverting the role file plus the catalog, role-skill-map, and AGENTS.md planning entries.