### PR TITLE
feat(subagents): add orchestration support

### DIFF
--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -63,6 +63,7 @@
     "skills": [
       "create-task-file",
       "manage-task-issues",
+      "orchestrate-subagents",
       "pr-readiness-gate",
       "post-pr-qa",
       "clean-context"
@@ -70,6 +71,9 @@
     "commands": [
       "commands/create-task-file.sh",
       "commands/create-task-issue.sh",
+      "commands/create-subagent-plan.sh",
+      "commands/validate-subagent-plan.sh",
+      "commands/record-subagent-result.sh",
       "commands/import-task-from-issue.sh",
       "commands/sync-task-issues.sh",
       "commands/update-todo-checklist.sh",

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -92,6 +92,7 @@ Commands:
 Skills:
 - `create-task-file`
 - `manage-task-issues`
+- `orchestrate-subagents`
 - `pr-readiness-gate`
 - `post-pr-qa`
 - `clean-context`
@@ -99,6 +100,9 @@ Skills:
 Commands:
 - `commands/create-task-file.sh`
 - `commands/create-task-issue.sh`
+- `commands/create-subagent-plan.sh`
+- `commands/validate-subagent-plan.sh`
+- `commands/record-subagent-result.sh`
 - `commands/import-task-from-issue.sh`
 - `commands/sync-task-issues.sh`
 - `commands/update-todo-checklist.sh`

--- a/.roles/computer-science/project-manager/ROLE.md
+++ b/.roles/computer-science/project-manager/ROLE.md
@@ -22,6 +22,7 @@ Manage project execution so user goals become clear, sequenced, verifiable work 
 - Translate user requests into scoped tasks with explicit outcomes, assumptions, risks, and validation paths.
 - Maintain alignment between active work, task files, TODO checklists, issue links, and PR readiness gates.
 - Break complex work into execution lanes with clear ownership, dependencies, and integration checkpoints.
+- Create and maintain `../.ai/tasks/<task_name>/SUBAGENTS.md` as the durable lane plan for substantial parallel work.
 - Detect when user prompts specify a developer count, agent count, or parallel execution expectation.
 - Convert count-based prompts into a practical multi-agent or multi-developer plan without creating unnecessary coordination overhead.
 - Keep the main execution path focused on blockers, integration, verification, and user-visible decisions.
@@ -32,6 +33,7 @@ Manage project execution so user goals become clear, sequenced, verifiable work 
 - Start with the project outcome, then define the smallest useful plan that can be executed and verified.
 - Treat non-trivial work as a planning problem before it becomes an implementation problem.
 - When the prompt includes a developer or agent count, treat that count as a capacity constraint for task alignment.
+- Use `SUBAGENTS.md` to persist lane ownership, role IDs, agent types, write sets, dependencies, expected outputs, verification paths, integration order, and lane results.
 - Split work into parallel lanes only when the lanes can have distinct ownership, inputs, outputs, and verification evidence.
 - Prefer one owner per lane, with non-overlapping write scopes for implementation work.
 - Reserve one lane for integration, review, QA, or documentation when the requested count exceeds useful implementation parallelism.
@@ -47,9 +49,11 @@ When a user specifies capacity such as `2 developers`, `3 agents`, `use 4 worker
 2. Determine the natural parallelism in the task before assigning lanes.
 3. Create at most the requested number of active lanes unless the user explicitly asks for reserve or stretch lanes.
 4. Assign each lane a purpose, owned files or responsibility area, expected output, verification path, and dependency notes.
-5. Keep the main agent responsible for orchestration, critical-path blockers, final integration, and user communication.
-6. Use subagents only when the active environment supports them and the user's wording authorizes delegation or parallel agent work.
-7. If the requested count is larger than the safe parallelism, explain the smaller effective lane count and assign remaining capacity to review, QA, documentation, or standby support.
+5. Record the lane plan in `../.ai/tasks/<task_name>/SUBAGENTS.md` for substantial task-backed work.
+6. Validate lane roles, write sets, and required fields before delegation.
+7. Keep the main agent responsible for orchestration, critical-path blockers, final integration, and user communication.
+8. Use subagents only when the active environment supports them and the user's wording authorizes delegation or parallel agent work.
+9. If the requested count is larger than the safe parallelism, explain the smaller effective lane count and assign remaining capacity to review, QA, documentation, or standby support.
 
 ## Multi-Agent Execution Pattern
 
@@ -64,22 +68,28 @@ Use this shape for multi-agent planning:
 - Reason: <natural parallelism and constraints>
 
 ## Lanes
-1. <Lane name>
-   Owner: <agent/developer role>
-   Scope: <files, module, or responsibility>
-   Output: <deliverable>
-   Verification: <test, review, artifact, or evidence>
-   Dependencies: <none or named blockers>
+### lane-1
+- Role: <resolved role id or alias>
+- Agent type: <explorer|worker|default>
+- Status: planned
+- Scope: <files, module, or responsibility>
+- Write set: <none or comma-separated paths>
+- Dependencies: <none or lane IDs>
+- Expected output: <deliverable>
+- Verification: <test, review, artifact, or evidence>
 
 ## Integration
 - Merge order:
 - Conflict risks:
 - Final verification:
+
+## Results
 ```
 
 # Constraints
 
 - Do not create parallel lanes that require multiple agents to edit the same files without an explicit integration strategy.
+- Do not spawn or assign a lane until its role resolves and its `SUBAGENTS.md` fields validate.
 - Do not delegate the critical-path blocker when the main agent's next action depends on that result immediately.
 - Do not inflate plans to match a requested count when the work is safer as a smaller sequence.
 - Do not treat a task as complete without verification evidence or a clearly stated reason verification could not run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -133,10 +133,13 @@ When multiple roles are requested:
 - If something goes sideways, stop and re-plan immediately instead of pushing through a stale plan
 
 ## Subagent strategy
-- Use subagents liberally to keep the main context window clean
-- Offload research, exploration, parallel analysis, and focused investigations to subagents
-- For complex problems, throw more compute at the problem via subagents
-- Use one task per subagent for focused execution
+- Use the `computer-science/project-manager` planning lens before subagent execution when the user requests multiple agents/developers/workers or when natural parallelism is clear
+- Create or update `../.ai/tasks/<task_name>/SUBAGENTS.md` for substantial parallel work using `./commands/create-subagent-plan.sh`, then validate it with `./commands/validate-subagent-plan.sh`
+- Resolve every lane role with `./commands/resolve-role.sh` before assigning work; do not spawn a lane with unresolved role ambiguity, missing verification, overlapping write scope, or an immediate critical-path dependency
+- For Codex, map read-only investigation lanes to `explorer` agents and implementation lanes to `worker` agents with disjoint write sets
+- For non-Codex tools, use the same `SUBAGENTS.md` lane plan as portable delegation guidance or sequential fallback
+- Keep the main agent responsible for orchestration, critical-path blockers, final integration, final verification, and user communication
+- Record completed lane evidence with `./commands/record-subagent-result.sh` when a task-backed `SUBAGENTS.md` exists
 
 ## Self-improvement loop
 - After any user correction, update `../.ai/MEMORY.md` with the learned pattern

--- a/commands/create-subagent-plan.sh
+++ b/commands/create-subagent-plan.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/create-subagent-plan.sh "<task_name>" ["agent_count"] [--dry-run]
+
+Creates ../.ai/tasks/<task_name>/SUBAGENTS.md when it does not already exist.
+Use --dry-run to print the plan scaffold without writing files.
+EOF
+}
+
+task_name=""
+agent_count=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$task_name" ]]; then
+        task_name="$1"
+      elif [[ -z "$agent_count" ]]; then
+        agent_count="$1"
+      else
+        usage >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$task_name" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ -n "$agent_count" && ! "$agent_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "agent_count must be a positive integer: $agent_count" >&2
+  exit 1
+fi
+
+task_dir="../.ai/tasks/$task_name"
+target="$task_dir/SUBAGENTS.md"
+requested="${agent_count:-unspecified}"
+lane_count="${agent_count:-1}"
+
+write_plan() {
+  cat <<EOF
+# Subagent Plan: $task_name
+
+## Capacity
+- Requested: $requested
+- Effective lanes: $lane_count
+- Reason: TODO
+
+## Rules
+- Resolve each lane role with \`./commands/resolve-role.sh\` before delegation.
+- Use \`explorer\` for read-only lanes and \`worker\` for implementation lanes when Codex subagents are available.
+- Worker lanes must declare disjoint write sets.
+- Keep the main agent responsible for orchestration, critical-path blockers, integration, final verification, and user communication.
+
+## Lanes
+EOF
+
+  local i
+  for ((i = 1; i <= lane_count; i++)); do
+    cat <<EOF
+
+### lane-$i
+- Role: TODO
+- Agent type: TODO
+- Status: planned
+- Scope: TODO
+- Write set: TODO
+- Dependencies: none
+- Expected output: TODO
+- Verification: TODO
+EOF
+  done
+
+  cat <<EOF
+
+## Integration
+- Merge order: TODO
+- Conflict risks: TODO
+- Final verification: TODO
+
+## Results
+EOF
+}
+
+if [[ $dry_run -eq 1 ]]; then
+  echo "Dry run: would create $target"
+  echo
+  write_plan
+  exit 0
+fi
+
+mkdir -p "$task_dir"
+
+if [[ -f "$target" ]]; then
+  echo "$target already exists"
+  exit 0
+fi
+
+write_plan > "$target"
+echo "Created $target"

--- a/commands/record-subagent-result.sh
+++ b/commands/record-subagent-result.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/record-subagent-result.sh "<task_name>" "<lane_id>" "<status>" "<summary_file>" [--dry-run]
+
+Appends lane result evidence to ../.ai/tasks/<task_name>/SUBAGENTS.md.
+EOF
+}
+
+task_name=""
+lane_id=""
+lane_status=""
+summary_file=""
+dry_run=0
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)
+      dry_run=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      if [[ -z "$task_name" ]]; then
+        task_name="$1"
+      elif [[ -z "$lane_id" ]]; then
+        lane_id="$1"
+      elif [[ -z "$lane_status" ]]; then
+        lane_status="$1"
+      elif [[ -z "$summary_file" ]]; then
+        summary_file="$1"
+      else
+        usage >&2
+        exit 1
+      fi
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$task_name" || -z "$lane_id" || -z "$lane_status" || -z "$summary_file" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! "$lane_id" =~ ^lane-[a-z0-9][a-z0-9-]*$ ]]; then
+  echo "Invalid lane id: $lane_id" >&2
+  exit 1
+fi
+
+if [[ ! "$lane_status" =~ ^[a-z0-9]+(-[a-z0-9]+)*$ ]]; then
+  echo "Invalid status: $lane_status" >&2
+  exit 1
+fi
+
+if [[ ! -f "$summary_file" ]]; then
+  echo "Missing summary file: $summary_file" >&2
+  exit 1
+fi
+
+target="../.ai/tasks/$task_name/SUBAGENTS.md"
+if [[ ! -f "$target" && $dry_run -eq 0 ]]; then
+  echo "Missing subagent plan: $target" >&2
+  exit 1
+fi
+
+if [[ -f "$target" ]] && ! grep -Eq "^###[[:space:]]+${lane_id}[[:space:]]*$" "$target"; then
+  echo "Lane not found in $target: $lane_id" >&2
+  exit 1
+fi
+
+timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+
+make_entry() {
+  cat <<EOF
+
+### Result: $lane_id - $lane_status - $timestamp
+- Summary source: \`$summary_file\`
+
+\`\`\`text
+EOF
+  sed -e 's/\r$//' "$summary_file"
+  cat <<'EOF'
+```
+EOF
+}
+
+if [[ $dry_run -eq 1 ]]; then
+  echo "Dry run: would append result to $target"
+  if [[ ! -f "$target" ]]; then
+    echo "Dry run note: $target does not exist, so lane existence was not checked."
+  fi
+  make_entry
+  exit 0
+fi
+
+make_entry >> "$target"
+echo "Recorded $lane_id result in $target"

--- a/commands/validate-subagent-plan.sh
+++ b/commands/validate-subagent-plan.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/validate-subagent-plan.sh "<task_name|path>"
+
+Validates a SUBAGENTS.md lane plan.
+EOF
+}
+
+input="${1:-}"
+if [[ -z "$input" || "$input" == "-h" || "$input" == "--help" ]]; then
+  usage
+  [[ -z "$input" ]] && exit 1 || exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -f "$input" ]]; then
+  plan_path="$input"
+else
+  plan_path="../.ai/tasks/$input/SUBAGENTS.md"
+fi
+
+if [[ ! -f "$plan_path" ]]; then
+  echo "Missing subagent plan: $plan_path" >&2
+  exit 1
+fi
+
+trim() {
+  local value="$1"
+  value="${value//$'\r'/}"
+  value="$(printf '%s' "$value" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//')"
+  printf '%s' "$value"
+}
+
+lower() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+is_placeholder() {
+  local value
+  value="$(lower "$(trim "$1")")"
+  [[ -z "$value" || "$value" == "todo" || "$value" == "tbd" || "$value" =~ ^\<.*\>$ ]]
+}
+
+field_value() {
+  local block="$1"
+  local field="$2"
+  printf '%s\n' "$block" \
+    | sed -nE "s/^[[:space:]]*-[[:space:]]*${field}:[[:space:]]*(.*)$/\\1/p" \
+    | head -n1 \
+    | sed -E 's/\r$//; s/^[[:space:]]+//; s/[[:space:]]+$//'
+}
+
+normalize_path() {
+  local value
+  value="$(trim "$1")"
+  value="${value#./}"
+  value="${value%/}"
+  printf '%s' "$value"
+}
+
+paths_overlap() {
+  local left right
+  left="$(normalize_path "$1")"
+  right="$(normalize_path "$2")"
+  [[ "$left" == "$right" || "$left" == "$right"/* || "$right" == "$left"/* ]]
+}
+
+status=0
+current_lane=""
+current_block=""
+declare -A lane_seen
+declare -A deps_by_lane
+declare -A write_owner
+lane_ids=()
+
+process_lane() {
+  local lane_id="$1"
+  local block="$2"
+
+  if [[ -z "$lane_id" ]]; then
+    return 0
+  fi
+
+  if [[ -n "${lane_seen[$lane_id]:-}" ]]; then
+    echo "Duplicate lane id: $lane_id" >&2
+    status=1
+    return
+  fi
+
+  lane_seen["$lane_id"]=1
+  lane_ids+=("$lane_id")
+
+  local role agent_type scope write_set dependencies expected_output verification
+  role="$(field_value "$block" "Role")"
+  agent_type="$(field_value "$block" "Agent type")"
+  scope="$(field_value "$block" "Scope")"
+  write_set="$(field_value "$block" "Write set")"
+  dependencies="$(field_value "$block" "Dependencies")"
+  expected_output="$(field_value "$block" "Expected output")"
+  verification="$(field_value "$block" "Verification")"
+
+  local field_name field_content
+  for field_name in "Role" "Agent type" "Scope" "Write set" "Dependencies" "Expected output" "Verification"; do
+    field_content="$(field_value "$block" "$field_name")"
+    if is_placeholder "$field_content"; then
+      echo "$lane_id has missing or placeholder field: $field_name" >&2
+      status=1
+    fi
+  done
+
+  if ! bash "$script_dir/resolve-role.sh" "$role" >/dev/null 2>&1; then
+    echo "$lane_id has unresolved role: $role" >&2
+    status=1
+  fi
+
+  local normalized_agent_type
+  normalized_agent_type="$(lower "$(trim "$agent_type")")"
+  case "$normalized_agent_type" in
+    explorer|worker|default)
+      ;;
+    *)
+      echo "$lane_id has invalid Agent type '$agent_type' (expected explorer, worker, or default)" >&2
+      status=1
+      ;;
+  esac
+
+  deps_by_lane["$lane_id"]="$dependencies"
+
+  if [[ "$normalized_agent_type" == "worker" ]]; then
+    if [[ "$(lower "$(trim "$write_set")")" == "none" ]]; then
+      echo "$lane_id is a worker lane and must declare a non-empty write set" >&2
+      status=1
+      return
+    fi
+
+    local path existing_path
+    IFS=',' read -r -a write_paths <<< "$write_set"
+    for path in "${write_paths[@]}"; do
+      path="$(normalize_path "$path")"
+      if is_placeholder "$path" || [[ "$(lower "$path")" == "none" ]]; then
+        echo "$lane_id has invalid worker write path: $path" >&2
+        status=1
+        continue
+      fi
+
+      for existing_path in "${!write_owner[@]}"; do
+        if paths_overlap "$path" "$existing_path"; then
+          echo "Worker write set overlap: $lane_id '$path' conflicts with ${write_owner[$existing_path]} '$existing_path'" >&2
+          status=1
+        fi
+      done
+
+      write_owner["$path"]="$lane_id"
+    done
+  fi
+
+  return 0
+}
+
+while IFS= read -r line || [[ -n "$line" ]]; do
+  line="${line//$'\r'/}"
+  if [[ "$line" =~ ^###[[:space:]]+(lane-[a-z0-9][a-z0-9-]*)[[:space:]]*$ ]]; then
+    matched_lane="${BASH_REMATCH[1]}"
+    process_lane "$current_lane" "$current_block"
+    current_lane="$matched_lane"
+    current_block=""
+  elif [[ -n "$current_lane" ]]; then
+    current_block+="${line}"$'\n'
+  fi
+done < "$plan_path"
+process_lane "$current_lane" "$current_block"
+
+if [[ ${#lane_ids[@]} -eq 0 ]]; then
+  echo "No lane sections found in $plan_path (expected headings like '### lane-1')" >&2
+  status=1
+fi
+
+for lane_id in "${lane_ids[@]}"; do
+  deps="${deps_by_lane[$lane_id]:-}"
+  if [[ "$(lower "$(trim "$deps")")" == "none" ]]; then
+    continue
+  fi
+
+  while IFS= read -r dep; do
+    [[ -n "$dep" ]] || continue
+    if [[ -z "${lane_seen[$dep]:-}" ]]; then
+      echo "$lane_id depends on missing lane: $dep" >&2
+      status=1
+    fi
+  done < <(printf '%s\n' "$deps" | grep -oE 'lane-[a-z0-9][a-z0-9-]*' || true)
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "Subagent plan validation passed: $plan_path"
+fi
+
+exit "$status"

--- a/skills/orchestrate-subagents/SKILL.md
+++ b/skills/orchestrate-subagents/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: orchestrate-subagents
+description: Plan and coordinate parallel subagent lanes using OpenCaw roles, durable task artifacts, and tool-specific execution guidance.
+---
+
+## When to use
+Use when a user specifies an agent, developer, worker, or parallel execution count, or when `computer-science/project-manager` identifies work that can safely run in parallel.
+
+Use before spawning subagents or delegating work so each lane has a resolved role, explicit ownership, dependencies, expected output, and verification evidence.
+
+## Output
+- `../.ai/tasks/<task_name>/SUBAGENTS.md` lane plan
+- requested and effective capacity
+- lane IDs, role IDs, agent types, scopes, write sets, dependencies, outputs, and verification paths
+- integration order and conflict risks
+- subagent prompt text for each lane
+- recorded lane result summaries after agents finish
+
+## Notes
+- The project-manager role owns lane decomposition and effective parallelism decisions.
+- Resolve every lane role with `../commands/resolve-role.sh` before assigning work.
+- Use `explorer` for read-only investigation lanes and `worker` for implementation lanes when Codex subagents are available.
+- Worker lanes must have disjoint write sets. If safe disjoint ownership cannot be declared, keep the work local or sequential.
+- Never delegate the immediate critical-path blocker when the main agent needs that result before it can continue.
+- Keep OpenCaw portable: if a tool has no subagent runtime, use the same lane plan as delegation guidance or sequential execution order.
+
+## Subagent prompt template
+
+```markdown
+You are working as `<role-id>` on lane `<lane-id>`.
+
+You are not alone in the codebase. Other agents or the main agent may be working in parallel. Do not revert edits made by others. Keep your work inside your assigned scope and adjust to compatible changes if you encounter them.
+
+Scope:
+- <files, module, or responsibility>
+
+Write set:
+- <paths this lane may edit, or none for read-only lanes>
+
+Dependencies:
+- <none or named blockers>
+
+Expected output:
+- <deliverable>
+
+Verification:
+- <commands, checks, artifacts, or review evidence>
+
+Final response requirements:
+- summarize what you did
+- list files changed
+- provide verification evidence
+- call out blockers, conflicts, or residual risks
+```
+
+## Commands
+../commands/create-subagent-plan.sh "<task_name>" ["agent_count"] [--dry-run]
+
+../commands/validate-subagent-plan.sh "<task_name|path>"
+
+../commands/record-subagent-result.sh "<task_name>" "<lane_id>" "<status>" "<summary_file>" [--dry-run]


### PR DESCRIPTION
## Summary

Adds portable subagent orchestration support to OpenCaw, centered on the `computer-science/project-manager` planning lens and durable `SUBAGENTS.md` task artifacts.

## What changed

- Added `skills/orchestrate-subagents/SKILL.md` with lane-planning rules and a reusable subagent prompt template.
- Added executable commands:
  - `commands/create-subagent-plan.sh`
  - `commands/validate-subagent-plan.sh`
  - `commands/record-subagent-result.sh`
- Expanded `AGENTS.md` subagent strategy into a formal workflow: project-manager planning, role resolution, Codex agent type mapping, portable fallback, and lane evidence recording.
- Updated `computer-science/project-manager` to use `SUBAGENTS.md` as the durable lane artifact.
- Wired the new skill and commands into both role skill maps.

## Risks

Low to moderate. This adds baseline orchestration guidance and scripts, but does not introduce a runtime scheduler. The validator enforces lane fields, role resolution, agent type values, dependency references, and worker write-set overlap checks.

## Validation

- `bash ./commands/validate-opencaw.sh`
- `git diff --cached --check` before commit
- `bash ./commands/create-subagent-plan.sh example-task 3 --dry-run`
- `bash ./commands/validate-subagent-plan.sh .subagent-smoke/SUBAGENTS.md`
- `bash ./commands/record-subagent-result.sh example-task lane-1 passed .subagent-smoke/summary.txt --dry-run`
- Role resolution checks for `project-manager`, `qa-engineer`, and `frontend-developer`

## Deployment / rollback notes

No deployment impact. Rollback is reverting the new skill, the three commands, and the AGENTS/project-manager/role-skill-map wiring.