### PR TITLE
feat: add game art style and engine guidance

### DIFF
--- a/.architecture/BABYLONJS.md
+++ b/.architecture/BABYLONJS.md
@@ -1,0 +1,414 @@
+# BABYLONJS.md
+
+This repository follows a **Babylon.js browser 3D game architecture** for WebGL/WebGPU-backed games, simulations, product experiences, XR scenes, and browser-native interactive 3D applications.
+
+The architecture is optimized for:
+
+- Babylon.js as the browser 3D game and rendering engine foundation
+- TypeScript or JavaScript applications using ES modules and tree-shakeable packages
+- explicit ownership between Babylon runtime objects and project-owned gameplay systems
+- glTF/GLB-first asset loading and production pipelines
+- PBR, environment lighting, shadows, post-processing, and material budgets
+- physics, animation, GUI, input, audio, WebXR, and debug tooling as deliberate subsystems
+- browser lifecycle, resize, input, audio-unlock, context-loss, and mobile-performance constraints
+- measurable runtime performance and testable gameplay logic
+
+The goal is to keep the system:
+
+- clear about what Babylon owns and what the application/game owns
+- production-ready beyond Playground prototypes
+- resilient to scene transitions, asset failures, device capability differences, and long sessions
+- friendly to large asset pipelines and team-authored scenes
+- practical for turning Babylon.js into a full browser game runtime without hiding all behavior in meshes and callbacks
+
+---
+
+# Core Architecture Rule
+
+**Use Babylon.js as the rendering and game-runtime foundation, but keep durable gameplay state, progression, persistence, networking, and feature rules in project-owned systems.**
+
+Prefer:
+
+```text
+Game State / ECS -> Simulation Systems -> Babylon Scene Sync -> Babylon Engine -> WebGL/WebGPU
+```
+
+Avoid:
+
+```text
+Babylon Mesh / Node tree -> all gameplay truth, save data, input rules, networking, quests, inventory, and UI state
+```
+
+Babylon should own the engine, scene graph, cameras, meshes, materials, lights, animation groups, particles, physics plugin integration, GUI textures, XR session helpers, render loop, and debug surfaces. The project should own gameplay identity, rules, state machines, save data, asset manifests, networking contracts, analytics, entitlement checks, and tests.
+
+---
+
+# Recommended Structure
+
+```text
+src/
+  app/
+    createEngine.ts
+    createScene.ts
+    babylonConfig.ts
+  engine/
+    loop/
+    time/
+    input/
+    assets/
+    audio/
+    physics/
+    ecs/
+    rendering/
+    scenes/
+    gui/
+    xr/
+    debug/
+  game/
+    entities/
+    components/
+    systems/
+    levels/
+    cameras/
+    animation/
+    progression/
+    ui/
+    state/
+  infrastructure/
+  tests/
+assets/
+  models/
+  textures/
+  environments/
+  audio/
+  manifests/
+tools/
+  assets/
+```
+
+Framework integrations such as React, Vue, Angular, Next.js, or SPA routing should stay at the application boundary. Do not let component lifecycles accidentally create duplicate engines, scenes, input bindings, render loops, or audio contexts.
+
+---
+
+# Engine and Scene Ownership
+
+Create one owning Babylon engine per embedded runtime unless the product intentionally uses multiple canvases.
+
+Rules:
+
+- centralize `Engine` or `WebGPUEngine` creation in one application boundary
+- choose WebGL or WebGPU deliberately and document fallback behavior
+- keep the canvas, engine options, antialiasing, stencil/depth settings, hardware scaling, offline support, context-loss behavior, and resize policy explicit
+- use ES module packages such as `@babylonjs/core`, `@babylonjs/loaders`, `@babylonjs/gui`, and `@babylonjs/inspector` for production builds
+- prefer direct module imports and documented side-effect imports over importing all of Babylon when bundle size matters
+- avoid using Babylon's public CDN for production builds; host pinned packages and decoder assets through the project's own deployment path
+- dispose scenes, textures, materials, meshes, observables, GUI textures, physics objects, and post-processes when they leave ownership
+- prevent hot reload, route remounts, or modal shell changes from creating duplicate engines or render loops
+
+Recommended startup flow:
+
+```text
+create canvas -> create engine -> load runtime config -> create scene -> load assets -> attach input -> start loop
+```
+
+---
+
+# Scene Architecture
+
+Use scenes as lifecycle-managed runtime containers, not as the only project organization model.
+
+Recommended scene categories:
+
+- `BootScene`: device checks, engine setup, feature detection, telemetry defaults
+- `LoadingScene`: progress UI, asset manifest loading, shader/material warmup
+- `MenuScene`: menu cameras, GUI, settings, account/session routing
+- `GameplayScene`: world content, gameplay systems, cameras, lights, physics, animation, particles
+- `HudScene` or GUI layer: screen-space overlays, prompts, minimap, interaction hints
+- `DebugScene` or debug layer: inspector, performance counters, physics/collider views
+
+Rules:
+
+- separate scene creation, asset loading, activation, pause/resume, unload, and disposal
+- keep reusable systems outside individual scene files
+- keep scene-local Babylon nodes distinct from durable game state
+- create stable node naming conventions for imported meshes, cameras, lights, sockets, spawn points, and VFX anchors
+- keep render layers, layer masks, collision groups, camera rigs, and highlight/outline policies documented
+- make scene transitions explicit so old observers, timers, physics bodies, sounds, and GUI controls do not survive accidentally
+
+---
+
+# Game Loop and Time
+
+Babylon's render loop schedules rendering, but game correctness still needs a timing model.
+
+Rules:
+
+- use the engine render loop as the browser frame driver
+- separate input sampling, fixed simulation, physics stepping, animation updates, render synchronization, and scene rendering
+- use a fixed timestep for deterministic movement, physics-like interactions, combat timing, replays, or multiplayer correctness
+- cap catch-up steps after tab throttling, device sleep, breakpoint pauses, and slow frames
+- clamp deltas before passing them to camera smoothing, animation blending, particles, or tweens
+- pause or degrade updates on `visibilitychange`, route changes, overlays, focus loss, and battery-sensitive states
+- keep game systems independent enough to unit test without a live WebGL context
+
+Recommended flow:
+
+```text
+browser frame -> collect input -> fixed simulation steps -> sync Babylon nodes -> scene.render()
+```
+
+Use on-demand rendering only for static viewers, editors, configurators, or turn-based experiences that do not require continuous animation.
+
+---
+
+# State and Entity Model
+
+Babylon nodes are presentation and interaction objects. They should not be the only source of game truth.
+
+Rules:
+
+- keep durable state serializable and independent from `Mesh`, `TransformNode`, `Scene`, or `AnimationGroup` instances
+- store stable entity IDs and render handles rather than deriving all state from mesh names
+- use `metadata` or reserved node properties only for bridge data, debug tags, authored IDs, or editor/runtime links
+- prefer an ECS, data-oriented model, finite-state machines, or focused systems for medium and large games
+- keep gameplay commands separate from pointer/camera callbacks
+- document ownership for spawned entities, pooled entities, imported level nodes, decals, particles, GUI controls, and audio emitters
+- validate entity lifecycle: create, activate, update, disable, pool, dispose
+
+---
+
+# Assets and Loading
+
+Use an explicit asset contract before production content grows.
+
+Rules:
+
+- prefer glTF/GLB for runtime 3D assets
+- load production assets through manifests, registries, or asset services rather than scattered URLs
+- use Babylon loader module functions where they improve tree shaking and plugin options
+- import required loaders explicitly, such as `@babylonjs/loaders/glTF`
+- use `AssetsManager`, asset containers, or project loaders for grouped loading, progress, retry, cancellation, and scene ownership
+- document decoder hosting for Draco, Meshopt, KTX2/Basis, Havok, or other WASM/worker-backed resources
+- separate source art, optimized runtime exports, thumbnails, metadata, licensing, and generated files
+- handle missing files, failed decoders, partial loads, unsupported extensions, CORS errors, and slow networks
+- validate imported roots, pivots, units, bounds, sockets, animation groups, material names, collision proxies, and LODs
+
+Recommended asset contract:
+
+```text
+asset id -> source file -> runtime file -> loader options -> scale/origin -> materials -> animations -> colliders -> license -> owner
+```
+
+---
+
+# Materials, Lighting, and Rendering
+
+Babylon provides strong high-level rendering features. Use them with budgets.
+
+Rules:
+
+- prefer PBR materials for physically plausible 3D scenes unless the art direction requires unlit, stylized, toon, or custom shader materials
+- define environment texture, color management, exposure, tone mapping, and image-processing defaults in one rendering policy
+- use prefiltered environment textures for production PBR lighting
+- document real-time light count, shadow-caster count, shadow-map sizes, reflection probes, post-processes, transparency, particles, and skeletal mesh budgets
+- use material reuse, texture atlases, texture compression, instances, thin instances, LODs, impostors, and culling before adding content scale
+- avoid creating materials, textures, meshes, or post-processes every frame
+- centralize render pipelines, post-process chains, outline/highlight layers, glow layers, render targets, and camera layer masks
+- test scenes on low-end mobile, integrated GPUs, high-DPI displays, and throttled browser profiles
+
+Rendering policy should document:
+
+- WebGL/WebGPU choice and fallback
+- target frame rate and resolution scaling
+- device pixel ratio cap
+- shadow policy
+- texture-size limits
+- transparency sorting expectations
+- post-processing budget
+- XR performance constraints when applicable
+
+---
+
+# Physics and Collision
+
+Treat Babylon physics as a subsystem with explicit game rules around it.
+
+Rules:
+
+- choose and document the physics plugin, such as Havok, and how its WASM/assets are loaded
+- keep physics world setup, gravity, timestep, collision groups, trigger layers, and material/friction policy centralized
+- sync gameplay entities to physics bodies and Babylon nodes in a predictable order
+- use simplified collision meshes or authored collider proxies instead of high-poly render meshes
+- separate triggers, hit detection, navigation blockers, pickups, and physical collisions
+- avoid letting physics impulses become the only authority for gameplay rules unless that is the design
+- keep deterministic or multiplayer-critical simulation rules server-owned when using networking
+- expose debug views for colliders, raycasts, contact points, and physics performance
+
+---
+
+# Input, Cameras, and Controls
+
+Babylon cameras and camera inputs are useful defaults; game controls still need an action layer.
+
+Rules:
+
+- map raw keyboard, pointer, touch, camera input, gamepad, and XR controller events into game actions
+- document camera type and intent, such as `UniversalCamera`, `ArcRotateCamera`, custom follow camera, cinematic camera, or `WebXRCamera`
+- attach camera controls deliberately and remove or customize inputs that conflict with gameplay
+- use Pointer Lock only for camera modes that need unconstrained mouse movement and provide fallback behavior
+- poll gamepad state through a normalized action mapper
+- separate camera smoothing, collision, occlusion, zoom, follow targets, and shake from gameplay state changes
+- handle focus, pointer capture, browser gestures, fullscreen, orientation, and mobile virtual controls
+
+---
+
+# Animation
+
+Use Babylon animation groups and clips as presentation data, with gameplay-owned animation state.
+
+Rules:
+
+- import named animation groups from glTF/GLB where possible
+- document clip names, loop behavior, blend rules, root motion policy, event markers, and fallback idle states
+- keep animation state machines in game systems or character controllers
+- avoid making gameplay correctness depend on animation callback timing alone
+- validate skeletal scale, bind pose, bone naming, socket/attachment nodes, and retargeting assumptions
+- pool or dispose animation-heavy entities intentionally
+- test animation transitions in real gameplay camera angles, not only in isolated viewers
+
+---
+
+# GUI and UI Layers
+
+Choose deliberately between Babylon GUI, DOM UI, and framework UI.
+
+Rules:
+
+- use Babylon GUI for in-world panels, diegetic controls, XR-friendly surfaces, and canvas-integrated HUDs
+- use DOM or framework UI for complex forms, account flows, accessibility-heavy menus, long text, settings pages, and responsive application chrome
+- keep UI state outside Babylon GUI controls when it must persist across scenes or route changes
+- define how screen-space labels, reticles, tooltips, health bars, minimaps, and prompts project from world coordinates
+- avoid expensive GUI pointer-move handling on complex meshes unless the interaction needs it
+- test high-DPI text, localization, focus order, controller navigation, touch targets, and mobile safe areas
+- keep HUD and in-world markers readable against lighting, post-processing, bloom, and camera movement
+
+---
+
+# Audio
+
+Browser game audio requires lifecycle and user-gesture handling.
+
+Rules:
+
+- unlock and resume audio only after a user gesture when browsers require it
+- separate music, ambience, UI, SFX, voice, and spatial audio buses or groups
+- attach listener behavior to the active camera or document an alternative listener model
+- keep positional audio emitters lifecycle-managed with entities
+- handle mute, pause, tab visibility, route changes, device sleep, and output-device changes
+- keep audio assets in manifests with loop points, compression choices, loudness targets, and ownership
+
+---
+
+# WebXR and Multi-Device Runtime
+
+Use Babylon WebXR helpers when XR is part of the product.
+
+Rules:
+
+- define whether XR is required, optional, or experimental
+- document supported modes: inline, immersive VR, immersive AR, hand tracking, controller input, teleportation, anchors, hit testing, or passthrough
+- keep non-XR camera and input paths functional unless the product is XR-only
+- budget XR scenes more aggressively than flat-screen scenes
+- keep comfort rules explicit: locomotion mode, snap/smooth turn, teleport, height calibration, vignette, and motion-sickness constraints
+- use mesh-based GUI or XR-compatible controls rather than assuming fullscreen 2D GUI works in immersive sessions
+- test entry/exit, lost tracking, controller disconnect, permissions, and unsupported devices
+
+---
+
+# Browser Integration
+
+Babylon games still live inside the browser platform.
+
+Rules:
+
+- handle `resize`, device pixel ratio changes, orientation changes, fullscreen entry/exit, focus loss, and `visibilitychange`
+- use browser storage, backend persistence, and cache policy deliberately; do not treat local IndexedDB/cache behavior as durable save storage without a product decision
+- keep service worker, asset caching, compression, CDN, and cache-busting policies explicit
+- avoid blocking the main thread with heavy parsing, pathfinding, mesh generation, or save serialization
+- use Web Workers or WASM where heavy CPU work is measurable and isolated cleanly
+- document CORS, cross-origin isolation, SharedArrayBuffer needs, and WASM decoder hosting when relevant
+- provide graceful errors for unsupported WebGL/WebGPU, disabled hardware acceleration, lost contexts, and low-memory devices
+
+---
+
+# Debugging and Observability
+
+Production Babylon projects need visibility beyond visual inspection.
+
+Rules:
+
+- enable the Inspector and debug layer only in development or privileged debug builds
+- use performance counters, scene instrumentation, engine FPS, GPU frame timing where available, and custom telemetry
+- expose debug overlays for draw calls, active meshes, texture memory, skeletons, particles, physics bodies, collisions, asset load time, and input state
+- log asset load failures with asset ID, URL, loader, decoder, and scene owner
+- capture recoverable context loss, unsupported feature paths, WebGPU fallback, and device capability decisions
+- add screenshot or pixel checks for critical scenes in browser automation when feasible
+- keep debug tooling tree-shakeable or excluded from production bundles
+
+---
+
+# Testing and Validation
+
+Test gameplay systems separately from Babylon surfaces, then verify browser rendering paths.
+
+Recommended coverage:
+
+- pure unit tests for gameplay rules, state machines, inventory, progression, combat, and deterministic simulation
+- asset manifest validation for missing files, duplicate IDs, invalid loader options, license metadata, texture size, and decoder requirements
+- scene smoke tests for engine creation, scene load, render frame, resize, dispose, and reload
+- browser tests for input, fullscreen, audio unlock, pointer lock, gamepad mapping, UI overlays, and route lifecycle
+- screenshot or canvas-pixel checks for nonblank scenes, visible cameras, major UI states, and lighting regressions
+- performance tests for representative scenes on target device classes
+
+Validation should fail when:
+
+- a scene cannot load all required assets
+- a render frame is blank unexpectedly
+- engine or scene disposal leaves duplicate loops or leaked observers
+- asset budgets exceed documented limits
+- production bundles import debug-only packages
+
+---
+
+# Anti-Patterns
+
+Avoid:
+
+- building the whole game inside one `createScene` function
+- treating mesh names as the only gameplay model
+- importing the entire Babylon namespace into every production module by habit
+- relying on CDN scripts for production deployments
+- leaving observers, GUI controls, physics bodies, or audio emitters alive after scene disposal
+- creating new materials, textures, meshes, vectors, or arrays every frame in hot paths without profiling
+- using render meshes as collision for complex levels
+- hiding business rules in pointer handlers, animation callbacks, or material metadata
+- assuming WebGPU, XR, gamepad, pointer lock, high-DPI, or audio autoplay behavior is universally available
+- shipping without asset failure states, feature fallback, performance budgets, and low-end device tests
+
+---
+
+# Code Generation Rules
+
+When generating Babylon.js code:
+
+- use TypeScript when the host project supports it
+- prefer ES module imports from `@babylonjs/*` packages
+- include required loader and feature side-effect imports explicitly
+- centralize engine and scene creation
+- keep Babylon runtime objects behind clear system boundaries
+- keep gameplay state serializable and testable outside Babylon
+- include resize, visibility, audio-unlock, and disposal behavior
+- add asset manifests instead of hard-coding many URLs
+- use glTF/GLB for 3D assets unless the project documents another pipeline
+- include debug tooling only behind environment gates
+- include browser verification for visible 3D scenes when changing rendering behavior

--- a/.architecture/COLYSEUS.md
+++ b/.architecture/COLYSEUS.md
@@ -1,0 +1,387 @@
+# COLYSEUS.md
+
+This repository follows a **Colyseus authoritative multiplayer architecture** for real-time game servers, rooms, matchmaking, state synchronization, reconnection, and multiplayer runtime operations.
+
+The architecture is optimized for:
+
+- Colyseus as an authoritative Node.js multiplayer server framework
+- TypeScript-first room, state, and message contracts
+- server-owned simulation and state mutation
+- schema-based state synchronization
+- explicit matchmaking and room lifecycle boundaries
+- reconnect-safe browser and game-engine clients
+- horizontal scaling with shared presence and room drivers
+- load testing, monitoring, graceful shutdown, and operational visibility
+
+The goal is to keep the system:
+
+- clear about what runs on the server and what runs on clients
+- resistant to cheating and invalid client messages
+- efficient with bandwidth and state patching
+- stable under disconnects, reconnects, process restarts, and scale-out
+- testable through room-level unit tests and load tests
+- compatible with browser clients, Phaser, Three.js, Unity, Godot, and other Colyseus SDK clients
+
+---
+
+# Core Architecture Rule
+
+**Colyseus rooms are authoritative server sessions. Clients request actions; the server validates, simulates, mutates state, and synchronizes results.**
+
+Prefer:
+
+```text
+Client Input -> Validated Room Message -> Server Simulation -> Schema State Patch -> Client Presentation
+```
+
+Avoid:
+
+```text
+Client mutates game state -> server mirrors it -> other clients trust it
+```
+
+Clients may predict, interpolate, animate, and render, but durable gameplay facts must be owned by the room or by trusted backend services. The synchronized schema state is a network contract, not a dumping ground for every server variable.
+
+---
+
+# Recommended Structure
+
+```text
+src/
+  app.config.ts
+  index.ts
+  rooms/
+    LobbyRoom.ts
+    MatchRoom.ts
+    RelayRoom.ts
+    states/
+      MatchState.ts
+      PlayerState.ts
+      SharedTypes.ts
+    commands/
+    systems/
+    validators/
+  matchmaking/
+    filters.ts
+    reservations.ts
+    roomMetadata.ts
+  auth/
+    onAuth.ts
+    tokens.ts
+  persistence/
+    repositories/
+    saveSnapshots.ts
+  realtime/
+    transport.ts
+    presence.ts
+    driver.ts
+  telemetry/
+    metrics.ts
+    logging.ts
+  tests/
+    rooms/
+    loadtest/
+```
+
+Client repositories should keep Colyseus SDK integration behind a multiplayer service boundary, then adapt state callbacks into engine-specific systems for Phaser, Three.js, React, Unity, or other clients.
+
+---
+
+# Room Architecture
+
+Rooms are the primary Colyseus runtime boundary.
+
+Rules:
+
+- define one room class per session type, such as `LobbyRoom`, `MatchRoom`, `PartyRoom`, `WorldRoom`, or `RelayRoom`
+- treat every room instance as isolated session state with its own clients, lifecycle, and schema state
+- keep room creation options typed and sanitized before use
+- initialize state in `onCreate`
+- authenticate and authorize in `onAuth` before `onJoin`
+- allocate player state in `onJoin`
+- handle temporary disconnection in `onDrop` and successful return in `onReconnect`
+- perform final cleanup in `onLeave` and `onDispose`
+- use `onBeforeShutdown` for graceful shutdown behavior when active rooms need player notification or save handling
+- lock or dispose rooms deliberately when gameplay enters a non-joinable state
+
+Do not put all multiplayer behavior in one giant room. Move combat, movement, matchmaking filters, persistence, replay, and scoring into focused systems or command handlers.
+
+---
+
+# State Synchronization
+
+Colyseus synchronized state must be designed as a compact network model.
+
+Rules:
+
+- define synchronized state with `@colyseus/schema`
+- mutate synchronized state only on the server
+- expose the minimum state clients need to render and play
+- keep secrets, anti-cheat signals, hidden cards, private matchmaking data, and server-only calculations out of shared schema state
+- use nested `Schema` structures when models approach field limits or need ownership boundaries
+- keep server and client schema definitions in matching field order when concrete schema classes are shared across SDKs
+- use `MapSchema`, arrays, and child schemas intentionally; avoid large frequently changing structures that create unnecessary bandwidth
+- tune `patchRate` based on game genre, perceived latency, and bandwidth budget
+- use state views or filtered state when clients should see only part of the room state
+- treat full state on join and patch updates as separate performance concerns
+
+Recommended schema categories:
+
+- public player state: position, facing, animation state, health, connected flag
+- public match state: phase, timer, score, objectives, round index
+- replicated entities: projectiles, pickups, hazards, NPCs, interactables
+- private or filtered views: hand contents, fog-of-war, team-only data, hidden objectives
+
+---
+
+# Messages and Commands
+
+Client messages are requests, not trusted facts.
+
+Rules:
+
+- use a small, versioned message vocabulary
+- validate every client payload, preferably with schema validation such as Zod through Colyseus validation helpers
+- bind messages to command handlers or systems instead of embedding every rule in inline callbacks
+- rate-limit or reject spammy actions
+- enforce authorization from `client.auth`, room state, and gameplay phase
+- reject impossible movement, invalid targets, stale sequence numbers, and actions outside turn/phase rules
+- use unreliable messages only for data that can safely be dropped
+- keep important state changes represented in server state, not only in transient broadcasts
+
+Message contracts should document:
+
+- message name
+- payload schema
+- allowed room phase
+- sender requirements
+- server validation
+- resulting state changes or errors
+- whether it is reliable, unreliable, idempotent, or replay-sensitive
+
+---
+
+# Simulation, Tickrate, and Latency
+
+Choose a timing model based on genre.
+
+Rules:
+
+- use fixed tick simulation for real-time movement, physics-like resolution, combat timing, or deterministic replays
+- keep room clocks, timers, and delayed actions under room lifecycle ownership
+- separate server simulation ticks from state patch rate when needed
+- use client-side interpolation for remote entities and optional prediction/reconciliation for local movement-heavy games
+- keep server timestamps, input sequence numbers, and authoritative corrections explicit when prediction is used
+- define lag compensation only if the game design needs it and the exploit surface is understood
+- clamp delta values and guard against event-loop stalls
+- keep turn-based and async games event-driven where a fixed tick would add needless cost
+
+Do not make gameplay correctness depend on client frame rate.
+
+---
+
+# Matchmaking and Rooms
+
+Colyseus matchmaker APIs should be wrapped by product-specific matchmaking services.
+
+Rules:
+
+- expose only the matchmaker operations the client is allowed to call
+- prefer explicit matchmaking endpoints or services for ranked queues, parties, password rooms, invites, private rooms, and rematches
+- use room metadata for searchable room traits such as mode, map, region, rating band, team size, locked state, and visibility
+- lock rooms when joining should stop
+- validate seat reservations and join options in `onAuth` and `onJoin`
+- document when to use `join`, `joinOrCreate`, `create`, `joinById`, `reserveSeatFor`, or custom room IDs
+- keep lobby/queue/relay built-in rooms separate from gameplay rooms when behavior differs
+- avoid trusting client-provided matchmaking filters for rank, entitlement, inventory, or private access
+
+For cross-process deployments, remember that room data and seat reservations may involve shared driver and presence coordination.
+
+---
+
+# Reconnection and Lifecycle
+
+Temporary disconnection is normal in browser and mobile multiplayer.
+
+Rules:
+
+- implement `onDrop` when the game supports reconnection
+- call `allowReconnection` with a timeout appropriate to the game type
+- mark players disconnected in synchronized state so other clients can show UI
+- do not delete player state on drop if reconnection is allowed
+- perform final cleanup only in `onLeave` after reconnection fails or the client leaves intentionally
+- handle `onReconnect` by restoring connected state and resending any required client context
+- show reconnecting, failed-to-reconnect, and return-to-lobby UI on clients
+- define how buffered messages should be handled after reconnection
+- reject reconnection when the match ended, the user was kicked, or session ownership changed
+
+Fast action games usually need short reconnection windows. Turn-based or async rooms can tolerate longer windows when save/persistence supports it.
+
+---
+
+# Authentication and Security
+
+Every production room should have an explicit authentication posture.
+
+Rules:
+
+- implement static `onAuth` when the room instance is not needed for authentication
+- validate tokens, user identity, entitlement, ban status, matchmaking permission, region, and party membership before allowing join
+- treat a missing `onAuth` as development-only because it allows any client to connect
+- validate every message payload and authorization again inside room behavior
+- never trust client position, inventory, currency, score, damage, or cooldown claims
+- avoid leaking secrets, hidden state, admin controls, or private matchmaking data in schema state
+- rate-limit joins, messages, room creation, and reconnect attempts
+- keep admin/monitoring tools protected behind authentication and network controls
+- treat IP, device, telemetry, and session identifiers as privacy-sensitive
+
+Use HTTPS/WSS in production and keep CORS, reverse-proxy headers, and token handling explicit.
+
+---
+
+# Persistence and Databases
+
+Separate real-time room state from durable data.
+
+Rules:
+
+- keep authoritative room state in memory during the match
+- persist only durable facts such as results, progression, inventory, ratings, purchases, and long-lived world changes
+- snapshot long-lived rooms intentionally; do not rely on in-memory room state for durability
+- use repositories/services for database access instead of direct database calls scattered through room handlers
+- avoid blocking the room tick on slow persistence operations
+- make persistence idempotent for match results and reconnect-sensitive flows
+- write audit trails for ranked, economy, or moderation-sensitive outcomes
+- define recovery behavior after process crash or room disposal
+
+Driver and presence choices for Colyseus scaling are separate from product databases used for accounts, inventory, progression, or analytics.
+
+---
+
+# Scaling and Deployment
+
+Colyseus can scale horizontally, but room ownership matters.
+
+Rules:
+
+- start with a single process only for development or small deployments
+- use shared presence and driver, commonly Redis-backed, for multi-process or distributed deployments
+- understand that each room belongs to one Colyseus process and clients connect to the process that owns their room
+- configure public addresses so clients can establish WebSocket connections to the correct process
+- place a load balancer at the initial entry point while preserving the direct room connection flow required by Colyseus scaling
+- define region strategy, process count, max clients per room, max rooms per process, and autoscaling signals
+- use graceful shutdown to stop matchmaking, lock rooms, notify players, save state, and dispose rooms
+- keep environment variables, secrets, Redis/database URLs, TLS, ports, and public addresses externalized
+- validate local, staging, and production topology separately
+
+Colyseus Cloud may remove some self-hosting configuration responsibilities, but the game still needs room, state, auth, persistence, testing, and client behavior contracts.
+
+---
+
+# Transports and Clients
+
+Transport choice must match browser, native, and deployment needs.
+
+Rules:
+
+- default to WebSocket unless the project has a documented reason to choose uWebSockets.js, WebTransport, Bun WebSockets, or another transport
+- document client SDKs and supported engines: browser TypeScript, Phaser, Three.js, Unity, Godot, Defold, GameMaker, native, or others
+- keep client connection code behind a multiplayer service boundary
+- normalize room lifecycle events into engine-facing states: connecting, joined, reconnecting, left, failed, kicked
+- keep rendering state updates separate from raw Colyseus callback handlers
+- handle endpoint configuration, protocol selection, auth token refresh, region selection, and reconnection UI in client code
+- test client behavior on slow networks, tab backgrounding, mobile sleep, and browser refresh
+
+---
+
+# Observability and Operations
+
+Real-time multiplayer needs operational feedback loops.
+
+Required signals:
+
+- process uptime and memory
+- global and local CCU
+- room count by room type
+- room creation, join, leave, drop, reconnect, and dispose rates
+- matchmaking latency and failures
+- message rates and rejected messages
+- patch size, patch rate, and bandwidth estimates
+- tick duration, event-loop lag, and slow command handlers
+- persistence latency and failures
+- Redis/presence/driver connectivity
+- disconnect close codes and reconnect outcomes
+
+Use Colyseus monitoring and load testing tools during development and staging. Production monitoring should protect admin endpoints and export metrics/logs into the hosting platform's observability stack.
+
+---
+
+# Testing and Verification
+
+Use tests that exercise room logic without needing a full game client, then add client and load tests.
+
+Test categories:
+
+- unit tests for commands, validators, state transitions, match phases, scoring, and persistence adapters
+- Colyseus room tests for `onCreate`, `onAuth`, `onJoin`, messages, state patches, reconnects, leaves, and disposal
+- schema compatibility tests when clients share generated or mirrored schema definitions
+- matchmaking tests for joins, full rooms, locked rooms, private rooms, ratings, regions, and denied clients
+- security tests for invalid payloads, unauthorized joins, spammy messages, and impossible actions
+- load tests with scripted bots using `@colyseus/loadtest`
+- browser or engine integration tests for join, state callback handling, reconnect UI, and rendering of remote entities
+- deployment smoke tests for public address, WSS, reverse proxy, Redis presence/driver, and graceful shutdown
+
+Do not call multiplayer work complete without at least one automated room test and one runtime connection smoke test.
+
+---
+
+# Anti-Patterns
+
+Never introduce:
+
+- client-authoritative health, damage, movement, score, inventory, or currency
+- mutable schema state reassigned wholesale after room startup
+- hidden gameplay rules inside unvalidated message callbacks
+- every room type sharing one giant state schema
+- private state placed in shared room state by default
+- missing `onAuth` in production rooms
+- Redis or database calls directly inside hot message paths without timeout and error handling
+- scaling assumptions that ignore room ownership by process
+- room cleanup that deletes players before reconnection can succeed
+- monitoring/admin endpoints exposed without protection
+- load-testing conclusions based on local loopback only
+
+---
+
+# Reference Sources
+
+- Colyseus documentation: https://docs.colyseus.io/
+- Rooms: https://docs.colyseus.io/room
+- State synchronization: https://docs.colyseus.io/state
+- Match-maker API: https://docs.colyseus.io/server/matchmaker
+- Reconnection: https://docs.colyseus.io/room/reconnection
+- Room authentication: https://docs.colyseus.io/auth/room
+- Presence: https://docs.colyseus.io/server/presence
+- Driver: https://docs.colyseus.io/server/driver
+- Scalability: https://docs.colyseus.io/scalability
+- Monitoring panel: https://docs.colyseus.io/tools/monitoring
+- Load testing: https://docs.colyseus.io/tools/loadtest
+
+---
+
+# Code Generation Rules for Agents
+
+When generating Colyseus multiplayer code:
+
+1. Start with room boundaries, state schema, message contracts, auth policy, and matchmaking flow.
+2. Keep server simulation authoritative and validate every client payload.
+3. Design synchronized schema state for bandwidth and visibility, not convenience.
+4. Implement reconnect behavior before calling a room production-ready.
+5. Keep client SDK callbacks behind a multiplayer service layer.
+6. Add unit tests for room lifecycle and message handling.
+7. Add load-test scripts before scaling claims.
+8. Document Redis/presence/driver/public-address requirements for multi-process deployment.
+
+When in doubt:
+
+**Let Colyseus own real-time rooms; let your game own explicit authoritative rules.**

--- a/.architecture/INDEX.md
+++ b/.architecture/INDEX.md
@@ -6,6 +6,8 @@ Available templates in this OpenCaw baseline:
 - AZURE
 - AZURE_DEVOPS
 - AZURE_STORAGE_TABLES
+- BABYLONJS
+- COLYSEUS
 - COSMOSDB
 - DATABRICKS
 - DOCKER
@@ -23,6 +25,7 @@ Available templates in this OpenCaw baseline:
 - MYSQL
 - NEXTJS
 - NODE
+- PHASERJS
 - POSTGRESDB
 - PYTHON
 - PLAYWRIGHT
@@ -32,6 +35,8 @@ Available templates in this OpenCaw baseline:
 - SPA
 - SQLITE
 - TERRAFORM
+- THREEJS
+- TILED
 - VUE
 
 Use one or more of these when generating `../ARCHITECTURE.md` for a host repository.

--- a/.architecture/LANGUAGE_SUPPORT.md
+++ b/.architecture/LANGUAGE_SUPPORT.md
@@ -17,13 +17,17 @@ For implementation work, prefer this order unless the role cannot reasonably use
 | DOTNET | C#, .NET |
 | DOTNET_ASPIRE | C#, .NET |
 | MAUI | C#, .NET |
+| BABYLONJS | TypeScript, JavaScript, WebGL, WebGPU, WGSL / GLSL shader code |
+| COLYSEUS | TypeScript, JavaScript, Node.js, WebSocket, Redis-backed scaling |
 | NODE | JavaScript, TypeScript, Node.js |
+| PHASERJS | JavaScript, TypeScript, HTML5 Canvas, WebGL |
 | PLAYWRIGHT | TypeScript, JavaScript |
 | REACT | JavaScript, TypeScript |
 | NEXTJS | JavaScript, TypeScript |
 | ANGULAR | TypeScript, JavaScript |
 | VUE | JavaScript, TypeScript |
 | SPA | JavaScript, TypeScript |
+| THREEJS | JavaScript, TypeScript, WebGL, WebGPU, GLSL / shader code |
 | SIGNALR_WEBSOCKETS | C#, JavaScript, TypeScript |
 | PYTHON | Python |
 | SOLIDITY | Solidity, TypeScript (tooling/scripts) |
@@ -37,6 +41,7 @@ For implementation work, prefer this order unless the role cannot reasonably use
 | DOCKER | Dockerfile syntax, Docker Compose YAML, shell |
 | EMBEDDED_FIRMWARE | C, C++, CMake/RTOS configs |
 | TERRAFORM | HCL |
+| TILED | TMX/XML, JSON, TSX, TX, JavaScript/TypeScript scripting, Lua/CSV exports |
 | KUBERNETES | YAML |
 | HELM | YAML, Go templates |
 | GITHUB_ACTIONS | YAML |

--- a/.architecture/PHASERJS.md
+++ b/.architecture/PHASERJS.md
@@ -1,0 +1,393 @@
+# PHASERJS.md
+
+This repository follows a **Phaser.js browser game architecture** for HTML5 games that run in desktop and mobile browsers using Phaser's scene, renderer, input, audio, animation, loader, and physics systems.
+
+The architecture is optimized for:
+
+- Phaser as the browser game engine foundation
+- JavaScript or TypeScript game code
+- explicit Scene lifecycle ownership
+- asset-manifest-driven loading
+- deterministic game state outside ad hoc object callbacks
+- mobile-friendly 2D rendering performance
+- browser input, audio, fullscreen, orientation, and visibility constraints
+- testable game systems around Phaser runtime surfaces
+
+The goal is to keep the system:
+
+- clear about what Phaser owns and what project-specific game systems own
+- organized around Scenes, systems, and asset contracts
+- stable across route changes, restarts, pause/resume, and mobile browser behavior
+- measurable for frame time, memory, asset load time, and input latency
+- simple enough for fast iteration without turning every Scene into a hidden global object
+
+---
+
+# Core Architecture Rule
+
+**Use Phaser as the runtime engine, but keep game rules, progression, save state, asset manifests, and feature systems explicit.**
+
+Prefer:
+
+```text
+Game Config -> Boot/Preload Scene -> Gameplay Scenes -> Game Systems -> Phaser Objects
+```
+
+Avoid:
+
+```text
+one giant Scene -> all input, all state, all physics, all UI, all loading, all save behavior
+```
+
+Phaser owns the game loop, Scene lifecycle, display list, renderer, cameras, loader, texture/cache managers, input plugins, sound, animations, time, tweens, and physics integration. The project should still define its own game-state model, save data, level manifests, entity definitions, progression rules, service integration, and testing boundaries.
+
+---
+
+# Recommended Structure
+
+```text
+src/
+  app/
+    createGame.ts
+    phaserConfig.ts
+  game/
+    scenes/
+      BootScene.ts
+      PreloadScene.ts
+      MainMenuScene.ts
+      GameplayScene.ts
+      HudScene.ts
+      PauseScene.ts
+    systems/
+      input/
+      combat/
+      movement/
+      spawning/
+      progression/
+      camera/
+      audio/
+    entities/
+    levels/
+    ui/
+    state/
+    assets/
+      manifests/
+      atlases/
+      audio/
+      tilemaps/
+  infrastructure/
+  tests/
+```
+
+Keep framework integration, routing, account flows, and page shell code outside the Phaser Scene tree. Phaser Scenes should be easy to start, stop, restart, pause, resume, and test in isolation.
+
+---
+
+# Game Instance and Configuration
+
+Phaser games should have one owning `Phaser.Game` instance per embedded game runtime.
+
+Rules:
+
+- centralize `Phaser.Game` creation in one application boundary
+- keep game configuration explicit: renderer type, parent element, dimensions, scale mode, background, physics, input, plugins, pixel-art flags, and scene list
+- prefer `Phaser.AUTO` when the product accepts Phaser's WebGL/Canvas selection, and document when a renderer must be forced
+- avoid creating duplicate game instances during hot reload, route remounts, tab navigation, or UI framework lifecycle churn
+- destroy the game instance on permanent unmounts or app shutdowns
+- keep configuration environment-driven for asset base URLs, debug flags, telemetry, save endpoints, and feature gates
+
+---
+
+# Scene Architecture
+
+Scenes are Phaser's primary unit of organization. Use them deliberately.
+
+Recommended Scene roles:
+
+- `BootScene`: minimal configuration, device checks, global registry defaults, plugin setup
+- `PreloadScene`: shared assets, loading UI, asset manifests, texture/audio/font preparation
+- `MainMenuScene`: menu flow and game-start routing
+- `GameplayScene`: world simulation, entities, tilemaps, physics, gameplay cameras
+- `HudScene`: HUD, overlays, score, timers, inventory, minimaps, prompts
+- `PauseScene`: pause UI, settings, restart/quit flow
+- `TransitionScene`: fades, loading bridges, or world transitions when needed
+
+Rules:
+
+- use `init`, `preload`, `create`, and `update` for their intended lifecycle responsibilities
+- keep shared assets in boot/preload flows and scene-specific assets in the scene that uses them
+- treat Scene shutdown and destroy as cleanup points for events, timers, tweens, listeners, subscriptions, and external resources
+- communicate between Scenes through explicit events, scene plugins, registry values, or an application state service
+- avoid reaching into sibling Scenes for hidden state unless the contract is documented
+- use simultaneous Scenes for HUD, pause overlays, debug overlays, and transitions when it keeps responsibilities cleaner
+
+---
+
+# State and Game Systems
+
+Phaser Game Objects are render and interaction objects, not the only domain model.
+
+Rules:
+
+- keep durable state such as progress, inventory, quests, unlocks, settings, player stats, save data, and analytics state in project-owned models
+- keep transient simulation state in entities/components/systems or focused feature modules
+- use Phaser `DataManager` for object-local or scene-local data, not as an unbounded substitute for an application model
+- use the global registry sparingly for small cross-scene values such as settings, session flags, or score snapshots
+- keep gameplay rules out of raw pointer handlers and animation callbacks when they belong in systems
+- model entity lifecycle explicitly: spawn, activate, update, disable, recycle, destroy
+- prefer finite-state machines, behavior modules, or ECS-style systems when entity behavior becomes complex
+
+---
+
+# Asset Pipeline
+
+Use Phaser's Loader and cache systems through manifests and named contracts.
+
+Rules:
+
+- use unique, namespaced asset keys
+- load shared assets in `BootScene` or `PreloadScene`
+- load scene-local assets in the owning Scene and remove them when memory matters
+- prefer texture atlases or multi-atlases for sprites that animate together or share draw paths
+- use sprite sheets only when frame dimensions and spacing are stable
+- use file packs or asset manifests for level, biome, character, UI, audio, and localization asset groups
+- keep raw asset URLs out of gameplay systems
+- document frame dimensions, atlas keys, animation keys, audio keys, tilemap keys, bitmap font keys, and plugin assets
+- handle loader progress, completion, and errors; do not assume every asset request succeeds
+- keep source art, optimized runtime exports, metadata, licensing, and generated files separate
+
+Recommended asset manifest shape:
+
+```text
+asset key -> type -> url(s) -> frame config -> owning scene/pack -> license/source -> memory notes
+```
+
+---
+
+# Rendering, Cameras, and Scale
+
+Phaser is a 2D engine with strong Scene, Camera, Game Object, and Scale Manager systems. Use those systems rather than manual DOM/canvas manipulation.
+
+Rules:
+
+- choose a base game size intentionally and document it
+- use the Scale Manager for fit, resize, expand, fullscreen, orientation, and parent-container behavior
+- keep UI layout aware of `gameSize`, `baseSize`, and `displaySize`
+- use cameras for world view, HUD exclusion, minimaps, follow behavior, bounds, dead zones, zoom, rotation, and screen effects
+- keep world coordinates, screen coordinates, UI coordinates, and camera transforms separate
+- define pixel-art rendering choices: round pixels, antialiasing, camera zoom, and texture filtering
+- do not use CSS transforms as a substitute for Phaser scale/camera policy unless the embedding shell explicitly owns presentation
+
+---
+
+# Input Architecture
+
+Phaser provides unified pointer, keyboard, and gamepad handling. The game should still define action mapping.
+
+Rules:
+
+- map raw input events to semantic game actions such as move, interact, attack, cancel, pause, select, drag, and zoom
+- keep rebinding, accessibility, mobile controls, and controller mappings behind an input service
+- enable Game Object input only where needed with `setInteractive`
+- use Scene input plugins for local scene behavior and avoid global listeners that survive scene shutdown
+- normalize pointer/touch/mouse interactions into the same gameplay commands when possible
+- poll or handle gamepad state through a consistent action layer
+- account for focus loss, fullscreen changes, orientation changes, and browser gestures on mobile
+
+---
+
+# Physics
+
+Choose Phaser physics based on gameplay needs.
+
+Rules:
+
+- use Arcade Physics for fast rectangle/circle collision, platformers, top-down games, simple puzzles, and broad arcade behavior
+- use Matter Physics when bodies need polygons, compound bodies, constraints, joints, sensors, or more advanced full-body simulation
+- do not mix Arcade and Matter casually in the same gameplay area without an explicit bridge contract
+- define world units, gravity, collision categories, static bodies, dynamic bodies, sensors, triggers, and debug overlay behavior
+- keep render sprites and physics bodies synchronized through systems, not scattered callbacks
+- avoid high-detail visual shapes as collision shapes
+- turn off physics debug in production builds
+- use fixed or bounded physics updates when gameplay correctness requires stable collision timing
+
+---
+
+# Animation, Tweens, and Time
+
+Use Phaser's animation, tween, and clock systems as runtime services, with gameplay intent kept explicit.
+
+Rules:
+
+- define global animation keys for shared character, VFX, UI, and item animations
+- keep animation state machines separate from the animation clip definitions
+- use tweens for presentation, juice, UI, camera, and simple motion, not as hidden gameplay state unless documented
+- use timers and delayed calls through Scene time systems so pause/resume and Scene shutdown are manageable
+- document animation frame rate, loop behavior, chain behavior, interrupt rules, event timing, and hit-frame timing
+- avoid creating unbounded tweens, timers, or animation chains inside `update`
+
+---
+
+# Audio
+
+Use Phaser sound through an audio system that understands browser restrictions.
+
+Rules:
+
+- handle browser audio unlock and resume behavior from user gestures
+- separate music, ambience, UI, SFX, voice, and gameplay-important sounds
+- use audio sprites when they reduce request overhead and fit the content pipeline
+- stop, pause, resume, or fade sounds explicitly during Scene transitions and app lifecycle events
+- keep audio keys and volume/mute settings in a durable settings model
+- support missing or failed audio loads gracefully
+
+---
+
+# Browser Platform Requirements
+
+Browser Phaser games must define platform assumptions up front.
+
+Required decisions:
+
+- target browsers and devices
+- desktop, mobile, tablet, embedded webview, or packaged wrapper targets
+- WebGL, Canvas, or auto renderer policy
+- base resolution, scale mode, orientation, fullscreen, and safe-area behavior
+- input modes: keyboard/mouse, touch, gamepad, virtual controls, drag/drop
+- audio unlock behavior
+- save strategy: localStorage, IndexedDB, backend save, or no saves
+- offline/cache strategy and asset versioning
+- analytics, crash reporting, and performance telemetry boundaries
+- accessibility expectations for contrast, text, remapping, reduced motion, and captions where relevant
+
+Do not claim mobile readiness until performance, input, audio, orientation, and fullscreen behavior have been tested on representative devices.
+
+---
+
+# Performance Rules
+
+Measure on target devices before and after optimization.
+
+Rules:
+
+- prefer atlases and batching-friendly assets over many small texture switches
+- reuse objects through pools for bullets, particles, enemies, pickups, hit effects, and temporary UI where churn is high
+- avoid per-frame allocation-heavy code in `update`
+- avoid creating tweens, timers, graphics, textures, groups, emitters, or physics bodies repeatedly inside hot loops
+- use `active`, `visible`, groups, cameras, culling, and pooling deliberately
+- keep particle counts, lights, masks, blend modes, large transparent sprites, and post-FX under budget
+- keep tilemap layer count, collision layer complexity, and camera effects budgeted
+- disable debug rendering in production
+- keep texture sizes and audio sizes appropriate for mobile memory limits
+- profile frame time, draw calls where available, physics cost, loader time, memory, and GC spikes
+- test Safari, Chrome, Firefox, mobile Chrome, and mobile Safari where those platforms are supported
+
+Acceptance targets should name:
+
+- target FPS and minimum acceptable FPS
+- maximum initial load and scene-transition load time
+- target base resolution and scale mode
+- maximum texture/audio memory expectations
+- supported input modes
+- lowest supported device class
+
+---
+
+# Packaging and Deployment
+
+Keep the game deployable as a browser app.
+
+Rules:
+
+- prefer modern bundling with explicit asset copying and hashed output
+- keep Phaser imports, plugins, and examples out of production bundles unless used
+- serve assets with correct MIME types, cache headers, compression, and CORS policy
+- version asset manifests so cached HTML/JS and cached assets do not disagree
+- keep service workers conservative unless offline play is a requirement
+- keep CSP compatible with the renderer, audio, fonts, workers, asset CDN, telemetry, and embedding requirements
+- define whether the game can run inside an iframe and whether fullscreen is allowed
+- document packaging tradeoffs for Capacitor, Cordova, Electron, or native wrappers if browser deployment is not enough
+
+---
+
+# Testing and Verification
+
+Use automated tests for systems and browser checks for runtime behavior.
+
+Test categories:
+
+- unit tests for pure systems: state machines, movement rules, damage, scoring, inventory, level parsing, input mapping, and save serialization
+- Scene lifecycle tests for create/shutdown/restart behavior where test harness support exists
+- asset manifest tests for missing keys, duplicate keys, wrong frame dimensions, and missing audio/atlas/tilemap files
+- browser tests for canvas creation, nonblank render, resize/scale behavior, route mount/unmount, keyboard/pointer/touch flows, and fullscreen/orientation behavior
+- visual tests for key scenes, HUD overlays, camera framing, tilemap alignment, and animation readiness
+- performance smoke tests for FPS, frame time spikes, object counts, physics cost, and loader time
+
+When Playwright is available, include a canvas nonblank check and a screenshot for critical scenes. Do not rely only on unit tests for a canvas game.
+
+---
+
+# Security and Safety
+
+- Do not load arbitrary remote scripts, plugins, asset packs, or user-generated assets without trust boundaries.
+- Keep API endpoints, asset hosts, telemetry, and save services configuration-driven.
+- Never put secrets in client game code or source-controlled assets.
+- Treat performance telemetry, device capability checks, and analytics as privacy-sensitive.
+- Validate downloaded level data, save data, and user-generated content before applying it to a live Scene.
+- Keep license and attribution records for asset packs, fonts, audio, plugins, and generated art.
+
+---
+
+# Anti-Patterns
+
+Never introduce:
+
+- one Scene that owns every feature forever
+- duplicate `Phaser.Game` instances caused by framework remounts
+- gameplay rules hidden in raw pointer callbacks, tween callbacks, or animation-complete handlers
+- raw asset URLs scattered through game logic
+- global registry abuse for all state
+- Scene transitions that leave event listeners, tweens, timers, audio, emitters, or physics bodies alive
+- unbounded object creation in `update`
+- production builds with debug physics, debug graphics, or verbose loader logging enabled
+- mobile support claims without real device checks
+- custom rendering, scaling, or input systems that fight Phaser's built-in managers without a documented reason
+
+---
+
+# Reference Sources
+
+- Phaser docs tooling: https://phaser.io/tools/phaser-docs
+- Phaser getting started / what is Phaser: https://docs.phaser.io/phaser/getting-started/what-is-phaser
+- Phaser Game concept: https://docs.phaser.io/phaser/concepts/game
+- Phaser Scene concept: https://docs.phaser.io/phaser/concepts/scenes
+- Phaser Scene API: https://docs.phaser.io/api-documentation/class/scene
+- Phaser Loader concept: https://docs.phaser.io/phaser/concepts/loader
+- Phaser Input concept: https://docs.phaser.io/phaser/concepts/input
+- Phaser Scale Manager concept: https://docs.phaser.io/phaser/concepts/scale-manager
+- Phaser Animations concept: https://docs.phaser.io/phaser/concepts/animations
+- Phaser Physics concept: https://docs.phaser.io/phaser/concepts/physics
+- Phaser Arcade Physics concept: https://docs.phaser.io/phaser/concepts/physics/arcade
+- Phaser Matter Physics concept: https://docs.phaser.io/phaser/concepts/physics/matter
+- MDN Gamepad API: https://developer.mozilla.org/docs/Web/API/Gamepad_API
+- MDN Web Audio API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
+- MDN Web Storage API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API
+- MDN IndexedDB API: https://developer.mozilla.org/en-US/docs/Web/API/IndexedDB_API
+
+---
+
+# Code Generation Rules for Agents
+
+When generating Phaser game code:
+
+1. Start with the Scene plan and game configuration.
+2. Define asset manifests, keys, and preload ownership before referencing assets.
+3. Keep gameplay state and save data outside raw Phaser Game Objects.
+4. Add input mapping, physics choice, animation keys, and UI Scene boundaries explicitly.
+5. Use pools or groups for high-churn objects.
+6. Clean up events, tweens, timers, audio, emitters, and external subscriptions on Scene shutdown.
+7. Verify canvas rendering, resize behavior, input, and representative performance in a browser.
+
+When in doubt:
+
+**Let Phaser run the game, but keep your game architecture explicit.**

--- a/.architecture/THREEJS.md
+++ b/.architecture/THREEJS.md
@@ -1,0 +1,342 @@
+# THREEJS.md
+
+This repository follows a **Three.js browser 3D architecture** for interactive WebGL/WebGPU-backed scenes, games, simulations, visualizers, and browser-native 3D experiences.
+
+The architecture is optimized for:
+
+- Three.js as the rendering layer
+- TypeScript or JavaScript browser applications
+- explicit game/runtime subsystem boundaries
+- glTF-first asset delivery
+- deterministic simulation where gameplay requires it
+- measurable browser and mobile performance
+- safe lifecycle management for GPU resources
+- graceful degradation across browser/device capability differences
+
+The goal is to keep the system:
+
+- clear about what Three.js owns and what the application engine owns
+- maintainable as scenes, assets, and gameplay systems grow
+- resilient to browser lifecycle, resize, input, audio, and GPU-context behavior
+- testable without relying only on visual inspection
+- practical for turning Three.js from a renderer into a browser game runtime
+
+---
+
+# Core Architecture Rule
+
+**Treat Three.js as the renderer and scene graph, not as the full game engine. Build explicit engine subsystems around it.**
+
+Prefer:
+
+```text
+Game State / ECS -> Simulation Systems -> Render Sync -> Three.js Scene -> WebGL/WebGPU
+```
+
+Avoid:
+
+```text
+Three.js Object3D tree -> all gameplay state, input rules, physics, networking, audio, and persistence
+```
+
+Three.js should own renderable objects, cameras, lights, materials, geometries, animation playback, ray queries, and renderer integration. Gameplay identity, rules, physics state, inventory, quests, AI, combat, save data, and networking state should live in application-owned systems.
+
+---
+
+# Recommended Structure
+
+```text
+src/
+  app/
+  engine/
+    loop/
+    time/
+    input/
+    assets/
+    audio/
+    physics/
+    ecs/
+    scenes/
+    rendering/
+    scripting/
+    persistence/
+  game/
+    entities/
+    components/
+    systems/
+    levels/
+    ui/
+  infrastructure/
+  tests/
+```
+
+Framework integrations such as React, Vue, Angular, Next.js, or SPA routing should stay at the application boundary. Do not let UI component lifecycles secretly own core game state unless the project intentionally uses a wrapper such as React Three Fiber and documents that ownership model.
+
+---
+
+# Rendering Boundary
+
+Rendering code should be isolated behind a small engine-facing API.
+
+Responsibilities:
+
+- create and configure `WebGLRenderer` or an explicitly selected `WebGPURenderer`
+- own the canvas, scene, camera, render targets, post-processing, and XR renderer hooks
+- handle viewport resize, device pixel ratio caps, camera aspect updates, and render target resizing
+- map game state into Three.js objects without making those objects the source of truth
+- dispose geometries, materials, textures, render targets, controls, and loaders when scenes unload
+
+Rules:
+
+- prefer `WebGLRenderer` for broad compatibility unless WebGPU requirements and fallback behavior are documented
+- cap pixel ratio on mobile and thermally constrained devices instead of blindly rendering at full device resolution
+- use `renderer.setAnimationLoop` when XR or renderer-managed loop integration is needed
+- use `requestAnimationFrame` or a renderer animation loop only as the frame scheduling mechanism, not as the whole engine architecture
+- centralize render layers, cameras, raycast layers, shadow settings, tone mapping, color management, and post-processing passes
+- handle WebGL context loss and restoration where the product cannot tolerate a blank canvas
+
+---
+
+# Game Loop and Time
+
+Browser games need a deliberate timing model.
+
+Rules:
+
+- separate frame scheduling, simulation update, physics stepping, animation update, and rendering
+- use a fixed timestep for physics and deterministic gameplay logic when collisions, combat timing, replays, or multiplayer correctness matter
+- cap catch-up steps to avoid spiral-of-death behavior after tab throttling, device sleep, slow frames, or debugger pauses
+- interpolate render transforms from the latest simulation state when fixed simulation and variable rendering are both used
+- pause or degrade updates on `visibilitychange`, focus loss, route changes, modal overlays, and battery-sensitive states
+- keep frame delta clamped before passing it to animation or camera smoothing code
+
+Recommended flow:
+
+```text
+browser frame -> collect input -> fixed simulation steps -> sync render objects -> render scene
+```
+
+Use on-demand rendering only for static scenes, configurators, editors, or product viewers. Games with animation, physics, AI, networking, or real-time input generally need a continuous loop while active.
+
+---
+
+# Engine Subsystems
+
+When Three.js is used as a browser game engine foundation, define these subsystems explicitly.
+
+## Entity and State Model
+
+- Prefer an ECS, data-oriented model, or explicit entity/system architecture for medium or large games.
+- Keep gameplay state serializable and independent from Three.js object instances.
+- Store references from gameplay entities to render handles, not the other way around.
+- Avoid putting rules into `Object3D.userData` except for bridge metadata, debug tags, or stable IDs.
+
+## Input
+
+- Centralize keyboard, pointer, touch, gamepad, and virtual-control handling.
+- Use Pointer Lock only for camera-control modes that need unconstrained mouse deltas, and provide fallback controls where support or user permission is unavailable.
+- Poll Gamepad API state in the game loop and normalize button/axis mappings into game actions.
+- Keep raw browser input events separate from gameplay commands so rebinding, accessibility, and replay tools remain possible.
+
+## Physics and Collision
+
+- Treat physics as a separate world with its own bodies, colliders, timestep, and synchronization step.
+- Sync physics transforms into Three.js meshes after simulation, not during random render code.
+- Use fixed steps for physics and cap substeps.
+- Keep collision layers, triggers, raycasts, character controllers, slope rules, and world units documented.
+- Prefer broad-phase-friendly static collision meshes over high-poly render meshes.
+
+## Animation
+
+- Use `AnimationMixer` for glTF clips and Three.js animation playback, but keep animation state machines in game/application code.
+- Separate clip loading, action selection, blend rules, root motion policy, and gameplay events.
+- Document whether movement is animation-driven, physics-driven, or gameplay-controller-driven.
+
+## Audio
+
+- Use Web Audio or Three.js audio wrappers behind an audio service.
+- Require user gesture handling for audio unlock and resume behavior.
+- Attach one listener to the active camera for positional audio unless the game documents another listener model.
+- Keep music, ambience, UI, SFX, voice, and spatial audio buses or groups separate.
+
+## Assets and Loading
+
+- Prefer glTF/GLB for runtime 3D asset delivery.
+- Use `GLTFLoader` with `LoadingManager` for progress, error handling, and grouped loading states.
+- Support Draco, Meshopt, and KTX2/Basis texture compression only when decoder hosting, CDN paths, browser support, and fallback behavior are documented.
+- Keep source assets, optimized runtime assets, thumbnails, metadata, and license records separate.
+- Load by manifest or asset registry rather than scattering raw URLs through gameplay code.
+- Validate missing assets, failed decoders, network errors, and partial-load states.
+
+## Scene and Level Management
+
+- Treat levels/scenes as lifecycle-managed modules: load, activate, pause, unload, dispose.
+- Avoid long-lived hidden Three.js objects after scene transitions.
+- Separate world content, UI overlays, debug helpers, cameras, lights, and transient effects.
+- For large worlds, define chunking, streaming, LOD, visibility, and origin/rebasing policies before content scale grows.
+
+## UI and Overlays
+
+- Keep DOM/UI framework state separate from render-loop state.
+- Avoid expensive DOM layout work inside the render loop.
+- Define how screen-space labels, HUD, minimaps, tooltips, and in-world markers map between 3D coordinates and UI layers.
+- Test pointer capture, focus, accessibility, and mobile touch behavior with both canvas and DOM overlays present.
+
+---
+
+# Asset Pipeline
+
+Use an explicit asset contract before production content grows.
+
+Recommended asset contract:
+
+- format: GLB/glTF, texture formats, compression, and decoder requirements
+- scale: world units, origin, pivot, bounds, forward/up axis, and collider proxy
+- materials: PBR expectations, unlit materials, transparency policy, color space, and texture channels
+- animation: clip names, loop flags, root motion policy, additive clips, and events
+- variants: skins, LODs, damage states, impostors, and platform-specific reductions
+- metadata: license, source file, export tool/version, optimization step, and owning feature
+
+Rules:
+
+- optimize for runtime delivery, not DCC convenience
+- reuse geometries, materials, and textures when possible
+- atlas, instance, merge, or LOD repeated content before adding more assets
+- avoid high-poly render meshes as collision geometry
+- keep texture sizes, shadow casters, transparency, post-processing, and skeletal counts under measured budgets
+
+---
+
+# Performance Rules
+
+Measure first, then optimize the largest bottleneck.
+
+Rendering rules:
+
+- minimize draw calls through instancing, batching, geometry merging, material reuse, and atlas strategies
+- use `InstancedMesh` or instanced glTF data for repeated objects
+- use LODs, impostors, culling, and visibility layers for large scenes
+- keep shadow maps, transparent materials, post-processing, and real-time lights budgeted
+- avoid per-frame geometry/material/texture creation
+- dispose GPU resources when no longer needed
+- prefer compressed textures and optimized meshes for web delivery
+- tune pixel ratio and render resolution before sacrificing core gameplay responsiveness
+
+Browser rules:
+
+- profile on target browsers and devices, especially mobile Safari/Chrome and integrated GPUs
+- account for tab throttling, thermal throttling, battery impact, low-memory devices, and context loss
+- use Web Workers or OffscreenCanvas only when the threading model, browser support, fallback, and message protocol are defined
+- avoid blocking asset parsing, decompression, pathfinding, generation, or AI work on the main thread when it causes frame drops
+
+Acceptance targets should name:
+
+- target FPS and minimum acceptable FPS
+- max load time and interactive time
+- max texture memory or approximate GPU memory budget
+- draw-call, triangle, light, shadow, particle, and skeleton budgets where relevant
+- target devices and browsers
+
+---
+
+# Browser Platform Requirements
+
+Three.js game architecture must document browser-facing requirements.
+
+Required decisions:
+
+- WebGL 1, WebGL 2, or WebGPU renderer support and fallback path
+- desktop, mobile, tablet, XR, or embedded-webview targets
+- input modes: keyboard/mouse, touch, pointer lock, gamepad, virtual joystick, XR controllers
+- audio unlock/resume behavior
+- fullscreen, orientation, viewport, and responsive canvas policy
+- persistence: localStorage, IndexedDB, backend saves, or no saves
+- worker/offscreen support and fallback
+- asset CDN/cache/versioning strategy
+- privacy and telemetry boundaries for performance diagnostics
+
+Do not assume every browser supports every game feature. Gate features by capability checks and keep unsupported states user-friendly.
+
+---
+
+# Testing and Verification
+
+Use automated and manual checks appropriate for visual/browser runtime risk.
+
+Test categories:
+
+- unit tests for pure game systems, math, state machines, input mapping, asset manifests, and simulation rules
+- integration tests for loader manifests, scene lifecycle, resource disposal, and physics/render sync
+- browser tests for canvas creation, route lifecycle, resize behavior, input flows, audio unlock, and no-blank-canvas regressions
+- visual or screenshot tests for camera framing, lighting, UI overlays, and important scenes
+- performance smoke tests for FPS, frame time spikes, draw calls, asset load time, and memory trends
+- target-device tests for mobile/touch, integrated GPUs, and browser-specific behavior
+
+For 3D browser apps, Playwright verification should include screenshots and canvas-pixel checks when a blank or misframed render would be user-visible.
+
+---
+
+# Security and Safety
+
+- Do not load arbitrary remote models, textures, shaders, or scripts without trust boundaries and CORS/content-security review.
+- Keep asset URLs, decoder paths, save endpoints, telemetry endpoints, and multiplayer endpoints configuration-driven.
+- Avoid putting secrets, privileged API tokens, or protected content in client assets.
+- Validate user-generated or downloadable content before adding it to a scene.
+- Treat WebGL fingerprinting, performance telemetry, and device capability collection as privacy-sensitive.
+
+---
+
+# Anti-Patterns
+
+Never introduce:
+
+- gameplay logic hidden in random `Object3D` callbacks or `userData`
+- frame-rate-dependent physics, combat, cooldowns, or movement
+- asset URLs scattered across components and systems
+- scene transitions that leave geometries, materials, textures, audio nodes, or event listeners alive
+- one giant scene module that owns input, physics, loading, rendering, UI, and gameplay rules
+- unbounded particle systems, dynamic lights, transparent materials, or post-processing chains
+- high-poly visual meshes used directly as collision geometry
+- per-frame allocation-heavy code in hot loops
+- mobile support claims without testing on real or representative devices
+- calling Three.js a complete game engine without defining missing subsystems
+
+---
+
+# Reference Sources
+
+- Three.js documentation and manual: https://threejs.org/docs/
+- Three.js responsive rendering guidance: https://threejs.org/manual/en/responsive.html
+- Three.js cleanup guidance: https://threejs.org/manual/en/cleanup.html
+- Three.js rendering-on-demand guidance: https://threejs.org/manual/en/rendering-on-demand.html
+- Three.js physics integration guidance: https://threejs.org/manual/en/physics.html
+- Three.js OffscreenCanvas guidance: https://threejs.org/manual/en/offscreencanvas.html
+- Three.js color management guidance: https://threejs.org/manual/en/color-management.html
+- Three.js GLTFLoader documentation: https://threejs.org/docs/pages/GLTFLoader.html
+- Three.js LoadingManager documentation: https://threejs.org/docs/pages/LoadingManager.html
+- Three.js WebGLRenderer documentation: https://threejs.org/docs/pages/WebGLRenderer.html
+- Three.js optimize-lots-of-objects guidance: https://threejs.org/manual/en/optimize-lots-of-objects.html
+- MDN WebGL best practices: https://developer.mozilla.org/en-US/docs/Web/API/WebGL_API/WebGL_best_practices
+- MDN Pointer Lock API: https://developer.mozilla.org/en-US/docs/Web/API/Pointer_Lock_API
+- MDN Gamepad API: https://developer.mozilla.org/docs/Web/API/Gamepad_API
+- MDN Web Audio API: https://developer.mozilla.org/en-US/docs/Web/API/Web_Audio_API
+- MDN OffscreenCanvas: https://developer.mozilla.org/docs/Web/API/OffscreenCanvas
+- MDN Web Workers: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API/Using_web_workers
+
+---
+
+# Code Generation Rules for Agents
+
+When generating Three.js browser game code:
+
+1. Start with engine subsystem boundaries, not with a monolithic scene file.
+2. Define renderer, loop, input, assets, scene lifecycle, and game-state ownership before adding content.
+3. Keep simulation/game state independent from Three.js objects.
+4. Use glTF/GLB manifests and loading services for assets.
+5. Cap and test device pixel ratio, resize behavior, and mobile performance.
+6. Dispose resources on unload and scene transitions.
+7. Add browser verification for nonblank rendering, interaction, resize, and representative performance.
+
+When in doubt:
+
+**Let Three.js render the world; let your application engine own the game.**

--- a/.architecture/TILED.md
+++ b/.architecture/TILED.md
@@ -1,0 +1,373 @@
+# TILED.md
+
+This repository follows a **Tiled / MapEditor level-authoring architecture** for tile maps, object layers, world files, custom properties, tilesets, collision metadata, and map export pipelines.
+
+The architecture is optimized for:
+
+- Tiled as the source-of-truth map and level editor
+- TMX, TSX, TX, JSON, and `.world` data contracts
+- 2D, isometric, staggered, hexagonal, and tile-based 2.5D worlds
+- explicit map-to-runtime transformation
+- stable tileset and object property schemas
+- Phaser, Three.js, custom canvas/WebGL, and native game runtime integration
+- reviewable map data and automated validation
+- large-world workflows that reduce memory pressure and merge conflicts
+
+The goal is to keep the system:
+
+- clear about what designers author in Tiled and what the runtime derives
+- deterministic about layers, collision, spawns, triggers, and metadata
+- resilient to asset path changes, tileset updates, map version drift, and export format differences
+- friendly to source control and team editing
+- efficient enough for browser games and mobile devices
+
+---
+
+# Core Architecture Rule
+
+**Treat Tiled as the level-authoring contract, not as the game runtime. Convert authored maps into explicit runtime systems.**
+
+Prefer:
+
+```text
+Tiled Project -> Maps / Tilesets / Templates -> Export / Validate -> Runtime Map Model -> Engine Systems
+```
+
+Avoid:
+
+```text
+Tiled JSON loaded directly everywhere -> hidden gameplay rules, collision, spawns, and entity behavior scattered through render code
+```
+
+Tiled should own map layout, tile placement, layers, tilesets, object placement, custom properties, terrain metadata, templates, and world composition. The runtime should own loading, schema validation, entity construction, collision conversion, navigation, rendering, streaming, save-state overlays, and gameplay interpretation.
+
+---
+
+# Recommended Structure
+
+```text
+assets/
+  maps/
+    source/
+      project.tiled-project
+      worlds/
+      maps/
+      tilesets/
+      templates/
+      automapping/
+    exported/
+      maps/
+      tilesets/
+      worlds/
+  tilesets/
+  sprites/
+src/
+  game/
+    maps/
+      loadMap.ts
+      validateMap.ts
+      mapSchema.ts
+      mapRegistry.ts
+      tileProperties.ts
+    levels/
+    collision/
+    spawning/
+    navigation/
+    rendering/
+tools/
+  tiled/
+    export-maps.*
+    validate-maps.*
+    scripts/
+```
+
+Keep editable source files and runtime exports distinct when the runtime does not consume the authoring format directly. If the runtime consumes Tiled JSON directly, still separate authored assets, generated caches, and validation reports.
+
+---
+
+# File Format Contract
+
+Choose the runtime map format intentionally.
+
+Rules:
+
+- prefer Tiled JSON for browser JavaScript/TypeScript runtimes unless a target engine has stronger TMX support
+- use TMX/TSX when XML tooling, editor interoperability, or engine support is stronger
+- keep external tilesets (`.tsx` or JSON tilesets) when maps share tile definitions
+- use object templates (`.tx`) for repeated entities, triggers, NPCs, pickups, doors, and spawn definitions
+- document whether maps use finite, infinite, orthogonal, isometric, staggered, or hexagonal orientation
+- document tile width, tile height, object coordinate assumptions, render order, chunking, compression, and layer ordering
+- avoid CSV except for simple tile layers with no object, property, template, or tileset complexity
+- do not depend on file paths that only work on one designer's machine
+
+Runtime loaders must handle:
+
+- missing maps, tilesets, images, and templates
+- duplicate asset keys or object IDs
+- unsupported Tiled version or format version
+- unknown layer classes or object classes
+- unexpected compression or encoding
+- flipped/rotated tile flags where the runtime supports them
+- external file references and relative paths
+
+---
+
+# Map Schema and Custom Properties
+
+Custom properties are the primary bridge from designer-authored maps to gameplay behavior.
+
+Rules:
+
+- define a typed property schema for maps, layers, tilesets, tiles, objects, object templates, Wang sets, and world entries when used
+- prefer Tiled custom classes and enums for structured designer input
+- keep property names stable, documented, and validated in CI or local tooling
+- use class names for gameplay objects such as `SpawnPoint`, `Door`, `NPC`, `Enemy`, `Pickup`, `Trigger`, `Region`, `CameraZone`, and `Hazard`
+- avoid free-form string conventions when an enum or custom class can prevent invalid data
+- use tile property inheritance for repeated tile-object behavior, but validate per-instance overrides
+- reserve properties for authored intent, not for runtime-only transient state
+
+Required schema decisions:
+
+- coordinate system and units
+- layer naming and class conventions
+- object class list
+- required and optional properties per class
+- property defaults and allowed values
+- collision and trigger representation
+- spawn and entity ID rules
+- asset references and relative path policy
+- localization/text handling policy
+
+---
+
+# Layer Architecture
+
+Layer names and classes are part of the map API.
+
+Recommended layer families:
+
+- `Ground`: base walkable or visual terrain
+- `DecorationBelow`: non-colliding visuals below actors
+- `Collision`: tile or object collision authoring
+- `Gameplay`: triggers, regions, spawns, doors, hazards, objectives
+- `Entities`: NPCs, enemies, pickups, interactables, scripted objects
+- `DecorationAbove`: props or visual layers above actors
+- `Occlusion`: roofs, trees, bridges, walls, foreground masks
+- `Parallax`: background or foreground image layers when supported
+- `Debug`: editor-only notes, boundaries, markers, and validation helpers
+
+Rules:
+
+- keep visual layers, collision layers, object layers, and debug layers separate
+- mark editor-only/debug layers so export or runtime import can exclude them
+- define draw order and depth behavior explicitly, especially for isometric and 2.5D maps
+- do not infer gameplay meaning from arbitrary layer order when a class/property is more reliable
+- keep layer opacity, tint, parallax, and visibility meaningful for runtime only when the engine supports them
+
+---
+
+# Tilesets and Terrain
+
+Tilesets should be stable runtime contracts, not just editor palettes.
+
+Rules:
+
+- keep tile dimensions, margin, spacing, image paths, tile IDs, and atlas relationships stable
+- use external tilesets for shared terrain, structures, props, hazards, and animated tiles
+- document tile property schemas for collision, material, footstep sound, biome, terrain type, damage, ladder, water, slope, cover, and interaction
+- validate that tile IDs used by maps still exist after tileset changes
+- prefer named tile properties or classes over relying only on raw global tile IDs
+- keep animated tile frame timing compatible with the runtime animation system
+- define whether Wang sets, terrains, or automapping rules are source-only authoring aids or runtime data
+
+For isometric projects, tilesets must align with `STYLE.md` and `ISOMETRIC_2_5D` style rules when present: projection, tile footprint, elevation step, collision readability, occlusion, and character anchor assumptions.
+
+---
+
+# Objects, Templates, and Entity Spawning
+
+Object layers are the main authored bridge to runtime entities.
+
+Rules:
+
+- use object templates for repeated authored entities
+- give every runtime-significant object a stable class and required properties
+- distinguish editor labels from runtime IDs
+- validate duplicate IDs, missing target references, and invalid object references
+- define how rectangles, points, polygons, polylines, ellipses, text, and tile objects are interpreted
+- convert Tiled objects into runtime entities through factory/registry code, not ad hoc switch statements in render code
+- keep spawn position, facing, team, behavior, loot, script, patrol path, trigger radius, and linked target properties explicit
+
+Do not encode full gameplay scripts in Tiled properties unless the project has a safe scripting architecture and validation story.
+
+---
+
+# Collision, Navigation, and Gameplay Data
+
+Collision and navigation should be derived predictably from authored data.
+
+Rules:
+
+- define whether collision comes from tile properties, collision object layers, tileset collision shapes, object classes, or generated navigation data
+- keep visual collision and runtime collision in sync through validation or debug overlays
+- avoid using high-detail decorative shapes as collision geometry
+- define one-way platforms, slopes, ladders, water, portals, doors, cover, hazards, and no-spawn regions explicitly
+- keep navigation graphs, path nodes, patrol routes, and trigger links named and validated
+- validate collision holes, unreachable spawns, overlapping blockers, duplicate exits, missing destinations, and orphaned references
+
+When using Phaser, map Tiled layers and objects through Phaser tilemap APIs while keeping gameplay conversion in project systems. When using Three.js or custom renderers, convert Tiled coordinates and layers into renderer-specific meshes, sprites, colliders, or data chunks behind a loader boundary.
+
+---
+
+# Worlds, Streaming, and Large Maps
+
+Use Tiled worlds for multi-map editing and large-world authoring.
+
+Rules:
+
+- use `.world` files when a game world spans multiple maps, chunks, regions, or screens
+- define global map positions in pixels and keep neighboring maps aligned
+- use naming patterns only when the pattern is documented and validated
+- load only adjacent maps or runtime-needed chunks for large worlds when memory or render cost matters
+- separate authored world placement from runtime streaming rules
+- define map boundary transitions, portals, edge stitching, and cross-map object references explicitly
+- keep map files small enough for review and team editing when possible
+
+For browser games, avoid loading entire large worlds into memory unless the target devices and performance budget support it.
+
+---
+
+# Export and Automation
+
+Map export should be repeatable.
+
+Rules:
+
+- automate exports with Tiled command-line options or scripts when generated runtime files are committed or packaged
+- use JavaScript/TypeScript Tiled scripts for custom export formats, validation helpers, custom actions, or editor tools when needed
+- use `@mapeditor/tiled-api` type definitions for typed Tiled scripts where practical
+- keep export scripts deterministic and source-controlled
+- run export validation in CI or pre-commit workflows when map data is critical
+- on Linux CI, account for Tiled needing a graphical environment for command-line exports and use a headless display setup when required
+- never hand-edit generated runtime exports unless the project explicitly treats them as source
+
+Recommended pipeline:
+
+```text
+edit map -> save source -> export/generate runtime data -> validate schema/assets -> run map smoke tests
+```
+
+---
+
+# Runtime Integration
+
+Keep runtime integration behind a map-loading boundary.
+
+Rules:
+
+- centralize map parsing, version checks, tileset resolution, property normalization, and entity spawning
+- expose runtime-specific map models instead of leaking raw Tiled JSON/TMX everywhere
+- keep renderer setup separate from gameplay object creation
+- validate layer names, object classes, required properties, tileset references, and asset existence before starting a level
+- generate actionable errors for designers: map file, layer, object ID/name, class, and missing property
+- keep save-game state as overlays on top of authored maps, not edits to source map files
+
+Integration notes:
+
+- Phaser can consume Tiled JSON through tilemap APIs, but project systems should still own gameplay conversion and entity spawning.
+- Three.js generally needs a custom conversion layer from Tiled maps into meshes, sprites, planes, instanced geometry, or 2.5D scene objects.
+- Custom canvas/WebGL runtimes should parse Tiled once into engine-friendly chunks, draw batches, collision structures, and entity spawn lists.
+
+---
+
+# Source Control and Review
+
+Map data is code-adjacent production data.
+
+Rules:
+
+- prefer stable formatting and deterministic exports for reviewable diffs
+- keep large binary source assets separate from map metadata where possible
+- avoid embedding tilesets when external tilesets reduce duplicated diffs
+- keep map files small enough to avoid frequent merge conflicts, or use world/chunk splitting
+- document which generated files are committed and which are build artifacts
+- include designer-facing validation errors in PR/CI output when map changes fail checks
+
+---
+
+# Testing and Verification
+
+Map changes need more than visual inspection in Tiled.
+
+Test categories:
+
+- schema validation for required layers, classes, and properties
+- asset validation for missing tilesets, images, templates, maps, and audio references
+- tile ID validation after tileset edits
+- collision and navigation validation
+- spawn/exit/portal/reference validation
+- export smoke tests for every committed map
+- runtime load tests for representative maps
+- browser tests for map render, collision debug overlays, object spawning, camera bounds, and scene transitions
+- screenshot or canvas checks for key levels when rendering risk is high
+
+Acceptance checks should include at least one real runtime load path, not only a successful Tiled save.
+
+---
+
+# Security and Safety
+
+- Do not load untrusted remote maps, scripts, or asset packs without validation and sandboxing.
+- Treat custom Tiled scripts as code; review them like build tooling.
+- Keep asset paths, export paths, and runtime URLs configuration-driven when environments differ.
+- Validate user-generated maps before loading them into a live game runtime.
+- Preserve licensing and attribution for tilesets, map packs, fonts, audio, and third-party templates.
+
+---
+
+# Anti-Patterns
+
+Never introduce:
+
+- gameplay-critical conventions that exist only in a designer's memory
+- raw Tiled JSON parsing scattered across game systems
+- layer names that change without migration or validation updates
+- stringly typed custom properties where classes/enums would prevent mistakes
+- maps that only work because assets exist at absolute local paths
+- generated exports committed without a reproducible export command
+- collision hidden in visual decoration with no debug or validation path
+- giant monolithic maps that cause memory, performance, or merge-conflict pain
+- runtime save-state changes written back into source map files
+- claiming map support without testing a map in the actual runtime
+
+---
+
+# Reference Sources
+
+- Tiled GitHub repository: https://github.com/mapeditor/tiled
+- Tiled documentation: https://doc.mapeditor.org/
+- Tiled custom properties: https://doc.mapeditor.org/en/stable/manual/custom-properties/
+- Tiled export formats: https://doc.mapeditor.org/en/stable/manual/export/
+- Tiled JSON map format: https://doc.mapeditor.org/en/stable/reference/json-map-format/
+- Tiled TMX map format: https://doc.mapeditor.org/en/stable/reference/tmx-map-format/
+- Tiled worlds: https://doc.mapeditor.org/en/stable/manual/worlds/
+- Tiled scripting API: https://www.mapeditor.org/docs/scripting/
+- Phaser Tilemap API: https://docs.phaser.io/api-documentation/class/tilemaps-tilemap
+
+---
+
+# Code Generation Rules for Agents
+
+When generating Tiled integration code:
+
+1. Start by identifying the selected source/export format and map schema.
+2. Define required layers, object classes, custom properties, tileset contracts, and asset paths before writing runtime loaders.
+3. Keep raw Tiled parsing behind a map-loading boundary.
+4. Convert maps into runtime models for rendering, collision, spawns, triggers, navigation, and camera bounds.
+5. Add validation with designer-friendly errors.
+6. Test at least one representative map in the actual runtime.
+7. Keep source maps, exported runtime files, and generated artifacts clearly separated.
+
+When in doubt:
+
+**Let Tiled author the world; let the runtime interpret it through validated contracts.**

--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -24,8 +24,16 @@ Current role catalog location:
 
 ### Arts & Visual Design
 - `css-vector-artist`
+- `cutout-rig-animator`
+- `flat-minimalist-game-artist`
+- `game-vfx-artist`
 - `generative-art-designer`
+- `illustrative-2d-artist`
+- `isometric-2-5d-art-director`
+- `isometric-2-5d-environment-artist`
+- `parallax-background-artist`
 - `pixel-artist`
+- `pre-rendered-2-5d-artist`
 - `tile-set-artist`
 
 ### Full Stack
@@ -73,8 +81,16 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `computer-science/code-migrator`: `code migrator`, `code-migrator`, `codemigrator`, `migration-engineer`, `modernization-engineer`
 - `computer-science/code-reviewer`: `code reviewer`, `code-reviewer`, `codereviewer`
 - `arts/css-vector-artist`: `css-vector-artist`, `css-vector`, `interface-vector-artist`, `logo-vector-artist`, `vector-ui-artist`
+- `arts/cutout-rig-animator`: `cutout-rig-animator`, `cutout-animator`, `skeletal-2d-animator`, `puppet-animation-artist`, `bone-rig-artist`, `sprite-rig-animator`
+- `arts/flat-minimalist-game-artist`: `flat-minimalist-game-artist`, `flat-game-artist`, `minimalist-game-artist`, `geometric-game-artist`, `monochrome-game-artist`, `simple-shape-artist`
+- `arts/game-vfx-artist`: `game-vfx-artist`, `2d-vfx-artist`, `sprite-vfx-artist`, `particle-vfx-artist`, `flipbook-vfx-artist`, `effects-artist`
 - `arts/generative-art-designer`: `generative-art-designer`, `generative-art`, `ai-image-designer`, `art-iteration-designer`, `image-prompt-designer`
+- `arts/illustrative-2d-artist`: `illustrative-2d-artist`, `hand-drawn-game-artist`, `painterly-2d-artist`, `painted-sprite-artist`, `concept-to-sprite-artist`
+- `arts/isometric-2-5d-art-director`: `isometric-2-5d-art-director`, `isometric-art-director`, `iso-art-director`, `isometric-game-art`, `isometric-style-director`, `isometric`
+- `arts/isometric-2-5d-environment-artist`: `isometric-2-5d-environment-artist`, `isometric-environment-artist`, `iso-environment-artist`, `isometric-world-artist`, `isometric-prop-artist`, `isometric-tiles-artist`
+- `arts/parallax-background-artist`: `parallax-background-artist`, `parallax-artist`, `background-layer-artist`, `scrolling-background-artist`, `atmospheric-background-artist`
 - `arts/pixel-artist`: `pixel-artist`, `pixel-art`, `sprite-artist`, `sprite-sheet-artist`, `raster-game-artist`
+- `arts/pre-rendered-2-5d-artist`: `pre-rendered-2-5d-artist`, `prerendered-2-5d-artist`, `hd-2d-artist`, `rendered-sprite-artist`, `orthographic-render-artist`, `3d-to-2d-artist`
 - `arts/tile-set-artist`: `tile-set-artist`, `tileset-artist`, `biome-artist`, `environment-tile-artist`, `terrain-artist`
 - `computer-science/data-engineer`: `analytics`, `data`, `data engineer`, `data-engineer`, `dataengineer`
 - `computer-science/database-optimizer`: `analytics`, `data`, `database optimizer`, `database-optimizer`, `databaseoptimizer`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -1,39 +1,203 @@
 {
   "arts/css-vector-artist": {
     "skills": [
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
       "enforce-art-language-safety"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
       "commands/print-css-art-token-template.sh",
       "commands/validate-svg-assets.sh"
     ]
   },
-  "arts/generative-art-designer": {
+  "arts/cutout-rig-animator": {
     "skills": [
+      "maintain-art-style-contract",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
       "iterate-art-to-sanity",
       "enforce-art-language-safety"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/flat-minimalist-game-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/game-vfx-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/generative-art-designer": {
+    "skills": [
+      "maintain-art-style-contract",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/illustrative-2d-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/isometric-2-5d-art-director": {
+    "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-tileset-sheet-template.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/isometric-2-5d-environment-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/print-tileset-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/parallax-background-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
       "commands/art-sanity-checklist.sh",
       "commands/validate-art-sanity-report.sh"
     ]
   },
   "arts/pixel-artist": {
     "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
       "iterate-art-to-sanity",
       "enforce-art-language-safety"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/pre-rendered-2-5d-artist": {
+    "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/print-tileset-sheet-template.sh",
+      "commands/print-directional-animation-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
       "commands/art-sanity-checklist.sh",
       "commands/validate-art-sanity-report.sh"
     ]
   },
   "arts/tile-set-artist": {
     "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "create-game-art-sheets",
+      "prepare-game-art-handoff",
       "iterate-art-to-sanity",
       "enforce-art-language-safety"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/print-tileset-sheet-template.sh",
+      "commands/print-game-art-handoff-template.sh",
       "commands/art-sanity-checklist.sh",
       "commands/validate-art-sanity-report.sh"
     ]
@@ -58,6 +222,9 @@
   },
   "qa-engineer": {
     "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
+      "prepare-game-art-handoff",
       "playwright-e2e-tests",
       "playwright-browser-discovery",
       "playwright-test-refinement",
@@ -67,6 +234,10 @@
       "test-dotnet"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/inspect-animation-sheet-folder.sh",
       "commands/playwright-install.sh",
       "commands/playwright-test.sh",
       "commands/playwright-show-report.sh",
@@ -121,21 +292,42 @@
   "fullstack-engineer": {
     "skills": [
       "generate-architecture",
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
       "solution-build",
       "test-dotnet"
     ],
     "commands": [
       "commands/generate-architecture.sh",
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/inspect-animation-sheet-folder.sh",
       "commands/dotnet-build.sh",
       "commands/dotnet-test.sh"
     ]
   },
+  "computer-science/frontend-developer": {
+    "skills": [
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff"
+    ],
+    "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
+      "commands/inspect-animation-sheet-folder.sh",
+      "commands/validate-svg-assets.sh"
+    ]
+  },
   "computer-science/game-designer": {
     "skills": [
+      "maintain-art-style-contract",
+      "review-isometric-production",
       "create-task-file",
       "manage-task-issues"
     ],
     "commands": [
+      "commands/validate-style-contract.sh",
+      "commands/print-isometric-production-checklist.sh",
       "commands/create-task-file.sh",
       "commands/update-todo-checklist.sh"
     ]

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -34,36 +34,192 @@ These skills and commands apply to all roles.
 
 ### arts/css-vector-artist
 Skills:
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
 - `enforce-art-language-safety`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
 - `commands/print-css-art-token-template.sh`
 - `commands/validate-svg-assets.sh`
 
-### arts/generative-art-designer
+### arts/cutout-rig-animator
 Skills:
+- `maintain-art-style-contract`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/flat-minimalist-game-artist
+Skills:
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/game-vfx-artist
+Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/generative-art-designer
+Skills:
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/illustrative-2d-artist
+Skills:
+- `maintain-art-style-contract`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/isometric-2-5d-art-director
+Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-tileset-sheet-template.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/isometric-2-5d-environment-artist
+Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/print-tileset-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/parallax-background-artist
+Skills:
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
 ### arts/pixel-artist
 Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/pre-rendered-2-5d-artist
+Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/print-tileset-sheet-template.sh`
+- `commands/print-directional-animation-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
 ### arts/tile-set-artist
 Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `create-game-art-sheets`
+- `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/print-tileset-sheet-template.sh`
+- `commands/print-game-art-handoff-template.sh`
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
@@ -86,6 +242,9 @@ Commands:
 
 ### qa-engineer
 Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
+- `prepare-game-art-handoff`
 - `playwright-e2e-tests`
 - `playwright-browser-discovery`
 - `playwright-test-refinement`
@@ -95,6 +254,10 @@ Skills:
 - `test-dotnet`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/inspect-animation-sheet-folder.sh`
 - `commands/playwright-install.sh`
 - `commands/playwright-test.sh`
 - `commands/playwright-show-report.sh`
@@ -146,20 +309,40 @@ Commands:
 ### fullstack-engineer
 Skills:
 - `generate-architecture`
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
 - `solution-build`
 - `test-dotnet`
 
 Commands:
 - `commands/generate-architecture.sh`
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/inspect-animation-sheet-folder.sh`
 - `commands/dotnet-build.sh`
 - `commands/dotnet-test.sh`
 
+### computer-science/frontend-developer
+Skills:
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
+
+Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
+- `commands/inspect-animation-sheet-folder.sh`
+- `commands/validate-svg-assets.sh`
+
 ### computer-science/game-designer
 Skills:
+- `maintain-art-style-contract`
+- `review-isometric-production`
 - `create-task-file`
 - `manage-task-issues`
 
 Commands:
+- `commands/validate-style-contract.sh`
+- `commands/print-isometric-production-checklist.sh`
 - `commands/create-task-file.sh`
 - `commands/update-todo-checklist.sh`
 

--- a/.roles/arts/css-vector-artist/ROLE.md
+++ b/.roles/arts/css-vector-artist/ROLE.md
@@ -14,7 +14,7 @@ vibe: Crafts expressive interface visuals with CSS and SVG precision.
 
 # Purpose
 
-Create scalable, production-ready interface art and logo systems using CSS and vector techniques only, with clear standards for proportion, depth, and usability.
+Create scalable, production-ready interface art, logo systems, HUD visuals, map symbols, and vector-native overlays using CSS and vector techniques only, with clear standards for proportion, depth, readability, and usability.
 
 # Responsibilities
 
@@ -24,6 +24,7 @@ Create scalable, production-ready interface art and logo systems using CSS and v
 - Establish size standards for icons, marks, lockups, and composition variants used in UI.
 - Establish depth standards (layering, shadow, highlight, and contrast) for logos and interface artwork.
 - Ensure interface artwork follows accessibility and legibility expectations in product contexts.
+- Support isometric-first games with HUD icons, minimap symbols, targeting markers, status badges, selection outlines, and overlays that remain readable on busy angled scenes.
 - Document usage guidance: minimum sizes, clear space, background compatibility, and prohibited transforms.
 
 # Behavior
@@ -35,6 +36,7 @@ Create scalable, production-ready interface art and logo systems using CSS and v
 - Keep depth subtle and purposeful so hierarchy improves without visual noise.
 - Prefer semantic CSS variables for visual systems to keep implementation portable and maintainable.
 - Validate visual consistency in light and dark contexts when artwork is intended for interface usage.
+- When vector art appears over an isometric game view, test it against representative terrain, foliage, structures, VFX, and combat states instead of flat mock backgrounds only.
 
 # Constraints
 
@@ -44,6 +46,7 @@ Create scalable, production-ready interface art and logo systems using CSS and v
 - Do not use arbitrary shadow stacks; each depth effect must map to a defined standard.
 - Do not ship interface artwork that fails contrast and legibility requirements for intended surfaces.
 - Do not blend unrelated visual styles in one asset set unless explicit art direction allows it.
+- Do not create raster world sprites, tiles, or isometric environment assets as this role's final output; hand those to the relevant raster or isometric role.
 
 # Collaboration
 
@@ -51,4 +54,6 @@ Create scalable, production-ready interface art and logo systems using CSS and v
 - Partner with `qa-engineer` to verify rendering fidelity, accessibility, and responsive behavior.
 - Partner with `technical-writer` to publish concise usage and brand safety guidance.
 - Partner with `software-architect` or `backend-architect` when rendering/performance constraints affect asset strategy.
+- Partner with `isometric-2-5d-art-director` when HUD, minimap, icon, or marker systems must align with an isometric game's visual language.
+- Partner with `flat-minimalist-game-artist` when vector UI needs a restrained shape, symbol, or state-language system.
 - During multi-role composition, preserve vector and CSS-only standards while adapting to product requirements.

--- a/.roles/arts/cutout-rig-animator/ROLE.md
+++ b/.roles/arts/cutout-rig-animator/ROLE.md
@@ -1,0 +1,56 @@
+---
+name: cutout-rig-animator
+description: 2D cutout and skeletal animation specialist focused on segmented sprites, pivots, bones, deformation, animation blending, and runtime-ready rigs.
+aliases:
+  - cutout-rig-animator
+  - cutout-animator
+  - skeletal-2d-animator
+  - puppet-animation-artist
+  - bone-rig-artist
+  - sprite-rig-animator
+category: arts
+color: purple
+vibe: Builds 2D puppets that bend cleanly and still read as game characters.
+---
+
+# Purpose
+
+Create segmented 2D character, creature, prop, and boss rigs for cutout or skeletal animation workflows, with clean pivots, hierarchy, deformation, state blending, and runtime handoff.
+
+# Responsibilities
+
+- Prepare layered body parts, clothing, weapons, accessories, facial states, hands, feet, wings, tails, and special deformation pieces for rigging.
+- Define hierarchy, root, pivots, rest pose, draw order, masks, bone names, attachment points, and export expectations.
+- Animate idle, locomotion, attack, hit, death, emote, interaction, and transition states with clear anticipation, contact, follow-through, and recovery.
+- Use cel-swap or replacement pieces for complex hands, feet, facial expressions, weapon arcs, and extreme poses when deformation would look wrong.
+- Validate rigs at gameplay camera scale with collision, hit effects, VFX, and expected facing directions.
+- Document animation state names, loop points, frame/event timing, anchors, and runtime constraints.
+- When exporting rigs to sheets, preserve action-separated filenames, direction rows, frame columns, transparent backgrounds, and stable pivots expected by the runtime.
+
+# Behavior
+
+- Start from the pose and pivot system. A rig with poor pivots will not animate cleanly.
+- Keep the hip/root or gameplay contact point stable unless the animation intentionally moves it.
+- Preserve silhouette and facing clarity even when pieces overlap or deform.
+- Use deformation sparingly where it helps organic motion; use replacement drawings when the shape change is too large.
+- For isometric games, align facings, foot anchors, and contact shadows with the active isometric projection.
+- Treat animation as gameplay communication: action timing and readable intent matter as much as smoothness.
+
+# Constraints
+
+- Do not accept rigs with drifting anchors, unstable pivots, broken hierarchy, or limbs that detach during motion.
+- Do not use skeletal deformation to hide missing drawings when a replacement pose is needed.
+- Do not ship animation states without loop, event, and transition expectations.
+- Do not change direction count, mirrored-frame assumptions, row order, or frame cell size without updating the sheet contract for engineering and QA.
+- Do not ignore draw order problems around arms, weapons, hair, wings, capes, or foreground props.
+- Do not change gameplay hit timing or collision without coordinating with design and engineering roles.
+
+# Collaboration
+
+- Partner with `illustrative-2d-artist` for segmented painted source art and replacement drawings.
+- Partner with `pixel-artist` when animations need sprite-sheet exports or pixel-clean cleanup.
+- Partner with `isometric-2-5d-art-director` for isometric facing, scale, contact anchors, and depth sorting.
+- Partner with `game-vfx-artist` for impact frames, weapon trails, particles, and readable combat feedback.
+- Partner with `game-designer` to align anticipation, contact, recovery, cancel windows, and hit feedback with gameplay intent.
+- Partner with `qa-engineer` to verify runtime animation states, pivots, sorting, looping, and event timing.
+- Partner with engineering roles when runtime rig formats, animation events, or state machines affect implementation.

--- a/.roles/arts/flat-minimalist-game-artist/ROLE.md
+++ b/.roles/arts/flat-minimalist-game-artist/ROLE.md
@@ -1,0 +1,53 @@
+---
+name: flat-minimalist-game-artist
+description: 2D game artist focused on flat, minimalist, monochrome, and geometric art systems with high readability and efficient production.
+aliases:
+  - flat-minimalist-game-artist
+  - flat-game-artist
+  - minimalist-game-artist
+  - geometric-game-artist
+  - monochrome-game-artist
+  - simple-shape-artist
+category: arts
+color: yellow
+vibe: Makes simple shapes carry sharp gameplay information.
+---
+
+# Purpose
+
+Create flat, minimalist, monochrome, or geometric 2D game art that emphasizes readable shapes, clear hierarchy, efficient production, and strong accessibility contrast.
+
+# Responsibilities
+
+- Design characters, icons, hazards, pickups, UI markers, props, backgrounds, map symbols, and simple scene elements using restrained shape and color systems.
+- Define shape grammar, color roles, value tiers, stroke rules, corner language, spacing, and motion/readability standards.
+- Build style tokens for gameplay states such as neutral, active, danger, disabled, collectible, objective, selected, and blocked.
+- Ensure important elements remain distinct for low vision and color vision deficiency scenarios.
+- Produce scalable source assets and raster exports when the runtime requires sprite atlases.
+- Document do/don't examples for visual hierarchy, clutter control, and state communication.
+
+# Behavior
+
+- Make shape and value carry meaning before hue or texture.
+- Prefer a small, intentional palette with clear semantic roles.
+- Keep backgrounds quiet enough for gameplay elements, UI, targeting, and text to remain legible.
+- Use repetition, alignment, spacing, and simple geometry to build visual cohesion.
+- For isometric-first games, use flat/minimalist art primarily for UI, overlays, tactical markers, minimaps, icons, or intentionally stylized assets unless the art director approves it for the full world.
+- Validate at small sizes and on busy backgrounds, not only on white or black canvases.
+
+# Constraints
+
+- Do not let minimalism become ambiguity; playable meaning must remain clear.
+- Do not rely only on color to distinguish critical states.
+- Do not overdecorate with gradients, shadows, or textures when the role is intentionally flat.
+- Do not create HUD or marker art that fails contrast against representative game scenes.
+- Do not override the isometric projection system with flat shapes unless they are UI overlays or explicitly approved world assets.
+
+# Collaboration
+
+- Partner with `css-vector-artist` for vector-native UI, icons, logos, and CSS/SVG implementation.
+- Partner with `isometric-2-5d-art-director` to align minimaps, markers, tactical overlays, and simple props with the main game view.
+- Partner with `game-designer` to ensure shape, value, and state tokens communicate mechanics without relying only on color.
+- Partner with `frontend-developer` when flat assets become reusable UI components.
+- Partner with `qa-engineer` to verify contrast, state distinction, and readability.
+- Partner with `technical-writer` to document symbol meaning and accessibility-safe usage.

--- a/.roles/arts/game-vfx-artist/ROLE.md
+++ b/.roles/arts/game-vfx-artist/ROLE.md
@@ -1,0 +1,55 @@
+---
+name: game-vfx-artist
+description: 2D game visual effects artist focused on readable gameplay feedback, sprite flipbooks, particles, shaders, timing, and runtime performance.
+aliases:
+  - game-vfx-artist
+  - 2d-vfx-artist
+  - sprite-vfx-artist
+  - particle-vfx-artist
+  - flipbook-vfx-artist
+  - effects-artist
+category: arts
+color: red
+vibe: Makes combat, magic, pickups, weather, and feedback feel alive without hiding the game.
+---
+
+# Purpose
+
+Create 2D game VFX that communicate gameplay clearly through timing, shape, color, value, particles, flipbooks, shaders, and controlled screen presence.
+
+# Responsibilities
+
+- Design impact, attack, magic, projectile, explosion, smoke, fire, water, dust, weather, pickup, healing, status, UI feedback, and environmental effects.
+- Define effect timing, anticipation, peak, dissipation, lifetime, draw order, blend mode, color roles, and gameplay meaning.
+- Produce sprite flipbooks, particle textures, masks, light cards, normal/specular support textures, and atlas-ready exports.
+- When effects are character-facing or action-attached, align flipbook frame counts, origin points, and direction rows with the owning character animation sheet contract.
+- Keep effects readable against representative terrain, characters, UI overlays, and camera zooms.
+- Document origin points, anchors, sorting layers, loop behavior, one-shot behavior, spawn rules, and performance constraints.
+- Validate that effects support gameplay feedback without obscuring hitboxes, hazards, targeting, or objective information.
+
+# Behavior
+
+- Start from gameplay intent: what happened, who caused it, where it happened, how urgent it is, and when the player needs to react.
+- Use strong silhouettes, value control, and motion arcs before adding particles or glow.
+- Keep VFX duration and screen coverage proportional to gameplay importance.
+- Design flipbooks and particles with atlas padding, transparent backgrounds, and predictable frame grids.
+- For isometric games, place origins and shadows on the ground plane and respect depth sorting around characters, walls, and props.
+- Use 2D lighting, normal maps, additive sprites, or shader effects only when they serve the art direction and runtime budget.
+
+# Constraints
+
+- Do not obscure critical gameplay information, UI text, targeting indicators, or collision boundaries.
+- Do not use excessive bloom, particles, opacity, or screen shake as a substitute for readable timing.
+- Do not mix unmatched blend modes, palette temperatures, or lighting assumptions within one effect family.
+- Do not ship flipbooks with inconsistent frame sizes, cropped effects, black backgrounds, or unclear loop points.
+- Do not ignore performance budgets for particle counts, texture size, overdraw, and mobile targets.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-art-director` for ground-plane placement, depth sorting, color language, and gameplay readability in isometric scenes.
+- Partner with `pixel-artist` or `illustrative-2d-artist` to match raster style and asset cleanup.
+- Partner with `cutout-rig-animator` for impact frames, weapon trails, hit flashes, and animation events.
+- Partner with `parallax-background-artist` for weather, ambience, fog, embers, and scene effects.
+- Partner with `game-designer` to map VFX timing, color, size, and intensity to player-readable feedback and fair telegraphs.
+- Partner with `qa-engineer` to verify effects do not obscure hitboxes, hazards, UI text, targeting, or objective information at target zoom.
+- Partner with engineering roles to validate shader, particle, atlas, and performance constraints.

--- a/.roles/arts/generative-art-designer/ROLE.md
+++ b/.roles/arts/generative-art-designer/ROLE.md
@@ -19,6 +19,7 @@ Design and refine model-generated visual assets using the native art generation 
 # Responsibilities
 
 - Create high-quality visual concepts, compositions, and prompt strategies using model-native image generation tools.
+- Capture camera, projection, scale, style, source-reference, and licensing assumptions for generated game-art concepts before handoff.
 - Run iterative generation passes until outputs satisfy defined sanity rules.
 - Enforce language rules for rendered text:
   - default to English text unless the user explicitly specifies another spoken language
@@ -32,6 +33,9 @@ Design and refine model-generated visual assets using the native art generation 
 # Behavior
 
 - Start with a clear intent brief: subject, style, composition, typography, and constraints.
+- For game-art concepts, include intended use case, camera view, projection, asset type, production role, and target style before generation.
+- For isometric-first concepts, specify the selected isometric projection, tile scale, lighting direction, visible sides, and whether the output is environment, character, prop, VFX, or UI reference.
+- Read host `STYLE.md` when present before creating art prompts, and use selected `.styles` templates as the durable source of style constraints.
 - Prefer short iterative loops over one-shot generation: generate, inspect, refine, and re-run.
 - Use a deterministic sanity checklist on every candidate image:
   - hand/anatomy correctness
@@ -50,6 +54,8 @@ Design and refine model-generated visual assets using the native art generation 
 - Do not produce graphic violence.
 - Do not bypass sanity checks to satisfy speed.
 - Do not claim an image passed checks without explicit verification against the checklist.
+- Do not claim generated concepts are production-ready sprites, tiles, atlases, rigs, or VFX until the responsible production art role has converted and validated them.
+- Do not hand off isometric concepts without camera/projection/style notes.
 
 # Collaboration
 
@@ -57,3 +63,5 @@ Design and refine model-generated visual assets using the native art generation 
 - Partner with `technical-writer` to document prompt templates and quality/safety checklists.
 - Partner with `frontend-developer` when generated assets must integrate into UI components.
 - Partner with `css-vector-artist` when composition should transition from generated concept art into production vector/CSS assets.
+- Partner with `isometric-2-5d-art-director` for isometric concepts, projection references, and production handoff standards.
+- Partner with `illustrative-2d-artist`, `pixel-artist`, `tile-set-artist`, `pre-rendered-2-5d-artist`, or `game-vfx-artist` when a generated concept needs production conversion.

--- a/.roles/arts/illustrative-2d-artist/ROLE.md
+++ b/.roles/arts/illustrative-2d-artist/ROLE.md
@@ -1,0 +1,54 @@
+---
+name: illustrative-2d-artist
+description: Hand-drawn and painterly 2D game artist focused on readable characters, props, icons, scenes, and production-ready raster illustration.
+aliases:
+  - illustrative-2d-artist
+  - hand-drawn-game-artist
+  - painterly-2d-artist
+  - painted-sprite-artist
+  - concept-to-sprite-artist
+category: arts
+color: orange
+vibe: Brings handcrafted 2D game art into shapes the game can actually use.
+---
+
+# Purpose
+
+Create hand-drawn, painterly, or illustrative 2D game assets that preserve strong silhouettes, consistent style, gameplay readability, and production handoff discipline.
+
+# Responsibilities
+
+- Produce characters, creatures, props, items, icons, portraits, splash art, key art, environment pieces, and concept sheets in an illustrative raster style.
+- Define line quality, brush texture, value range, rendering detail, palette, material treatment, and lighting direction for asset families.
+- Translate concepts into game-scale assets with clear silhouettes, anchors, transparency, cropping, and export formats.
+- Create turnaround or pose references when animation, facings, or isometric placement require consistency.
+- Validate assets at gameplay size against representative backgrounds, UI overlays, and camera zooms.
+- Document style rules so future generated or hand-painted assets can match the same visual language.
+
+# Behavior
+
+- Start with the playable read: shape, pose, value, facing, and scale before surface rendering.
+- Keep detail clustered around focal areas and simplify secondary forms that would become noise at game scale.
+- Separate concept exploration from production exports; a painting is not complete until it has anchors, scale, transparency, and use-case notes.
+- Respect the active projection for isometric work and record camera/projection assumptions in asset briefs.
+- Follow host `STYLE.md` and selected `.styles` templates for durable style decisions instead of inventing one-off art rules inside a task.
+- Use references ethically and preserve source, license, and derivative-use notes.
+- Prefer repeatable style recipes over one-off painterly effects that cannot scale across a game.
+
+# Constraints
+
+- Do not ship beautifully rendered assets that fail gameplay readability at target size.
+- Do not mix incompatible brush styles, line weights, lighting directions, or rendering detail within one asset family.
+- Do not provide final isometric assets without matching the active tile scale, anchor, and projection.
+- Do not use accidental text, watermarks, malformed anatomy, or unclear silhouettes in production art.
+- Do not leave exports without transparent backgrounds, safe cropping, or source notes when the asset needs runtime use.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-art-director` when illustrative assets must appear in the main isometric game view.
+- Partner with `cutout-rig-animator` when painted characters need segmented parts, pivots, or skeletal animation.
+- Partner with `pixel-artist` when illustrative concepts must become sprite sheets.
+- Partner with `generative-art-designer` for concept exploration, then perform production cleanup and style enforcement.
+- Partner with `css-vector-artist` when art needs separate UI, icon, or vector treatment.
+- Partner with `game-designer` when pose, silhouette, affordance, or focal detail affects player interpretation.
+- Partner with `qa-engineer` to verify target-size readability, transparency, contrast, and style consistency in representative scenes.

--- a/.roles/arts/isometric-2-5d-art-director/ROLE.md
+++ b/.roles/arts/isometric-2-5d-art-director/ROLE.md
@@ -1,0 +1,58 @@
+---
+name: isometric-2-5d-art-director
+description: Primary game-art director for isometric 2.5D visual systems, projection rules, elevation language, readability, and production handoff standards.
+aliases:
+  - isometric-2-5d-art-director
+  - isometric-art-director
+  - iso-art-director
+  - isometric-game-art
+  - isometric-style-director
+  - isometric
+category: arts
+color: teal
+vibe: Turns an isometric game view into a coherent production language.
+---
+
+# Purpose
+
+Own the isometric 2.5D art direction for games, including projection, tile metrics, elevation grammar, scene readability, lighting direction, atlas expectations, and cross-role visual consistency.
+
+# Responsibilities
+
+- Define the canonical isometric projection, tile footprint, elevation unit, camera angle, and scale relationships for characters, props, structures, terrain, VFX, UI markers, and shadows.
+- Establish the visual grammar for walkable ground, blockers, ledges, stairs, cliffs, roofs, doors, bridges, hazards, cover, interactables, and biome transitions.
+- Maintain the game-wide lighting direction, value structure, palette approach, material language, outline/edge language, and accessibility contrast expectations.
+- Specify depth-sorting and occlusion contracts for characters, tall props, walls, roofs, foliage, foreground overlays, and VFX.
+- Review generated concepts, tiles, sprites, props, backgrounds, UI markers, and pre-rendered assets for projection agreement before production use.
+- Follow host `STYLE.md` as the authoritative art contract when it exists, and use `./.styles/ISOMETRIC_2_5D.md` as the default template when an isometric style needs to be generated or refreshed.
+- Provide downstream acceptance criteria for design, engineering, QA, and documentation when isometric art decisions affect movement, collision, camera, sorting, UI markers, or asset metadata.
+
+# Behavior
+
+- Start by locking projection and scale before style detail: tile size, camera angle, elevation step, character height, door height, prop footprint, and anchor points come first.
+- Treat every asset as part of an assembled map. Judge art in scene context with characters, UI markers, collision expectations, and common camera zooms.
+- Prefer clear value grouping and silhouette readability over surface detail when the two compete.
+- Make occlusion predictable. If a sprite cannot sort cleanly as one image, require slices or layer metadata instead of accepting visual glitches.
+- Use the same contact-shadow, cast-shadow, and lighting language across sprites, props, structures, and terrain.
+- Translate broad style prompts into concrete isometric production rules so downstream roles can execute without guessing.
+
+# Constraints
+
+- Do not approve art that mixes incompatible projections, tile dimensions, lighting directions, outline weights, or character scale.
+- Do not treat a nice standalone concept image as production-ready unless it includes projection, scale, anchor, layer, palette, and atlas implications.
+- Do not hide gameplay-critical information under painterly detail, dark shadows, decorative foliage, or low-contrast markers.
+- Do not let roof, wall, tree, cliff, or tall-prop art ship without a depth-sorting and occlusion strategy.
+- Do not change gameplay movement, collision, or camera rules silently; call out when art direction requires engineering or design coordination.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-environment-artist` on terrain, structures, props, elevation, and scene composition.
+- Partner with `tile-set-artist` on tile metrics, transition sets, autotile rules, atlas grouping, and seam validation.
+- Partner with `pixel-artist` on isometric character anchors, facing, animation readability, and sprite scale.
+- Partner with `pre-rendered-2-5d-artist` when 3D-rendered source assets need to match the 2D isometric camera and atlas pipeline.
+- Partner with `game-vfx-artist` so effects preserve depth, contact points, timing, and gameplay clarity.
+- Partner with `css-vector-artist` on HUD, minimap, icons, targeting markers, and overlays that must read over busy isometric scenes.
+- Partner with `game-designer` on walkability cues, cover language, hazards, interactable affordances, and camera-dependent gameplay readability.
+- Partner with `frontend-developer` or `fullstack-engineer` on atlas metadata, pivots, sorting keys, runtime loaders, HUD overlays, and minimap/marker integration.
+- Partner with `qa-engineer` on scene-context checks for projection, sorting, occlusion, contrast, collision readability, and visual regression evidence.
+- Partner with `technical-writer` to keep `STYLE.md`, handoff notes, tile grammar, and isometric production rules understandable for future contributors.

--- a/.roles/arts/isometric-2-5d-environment-artist/ROLE.md
+++ b/.roles/arts/isometric-2-5d-environment-artist/ROLE.md
@@ -1,0 +1,56 @@
+---
+name: isometric-2-5d-environment-artist
+description: Environment artist for isometric 2.5D terrain, structures, props, elevation, occlusion, and gameplay-readable world scenes.
+aliases:
+  - isometric-2-5d-environment-artist
+  - isometric-environment-artist
+  - iso-environment-artist
+  - isometric-world-artist
+  - isometric-prop-artist
+  - isometric-tiles-artist
+category: arts
+color: green
+vibe: Builds readable isometric worlds where every floor, wall, roof, and prop knows where it stands.
+---
+
+# Purpose
+
+Create isometric 2.5D environments that obey the active projection, support gameplay readability, and assemble into coherent maps with reliable elevation, occlusion, and material language.
+
+# Responsibilities
+
+- Produce terrain, floor, wall, roof, cliff, stair, bridge, road, water, foliage, settlement, dungeon, interior, and prop art for isometric scenes.
+- Define asset footprints, base anchors, overhangs, sortable slices, collision hints, roof visibility needs, and layer expectations.
+- Build structures from map-safe parts such as base, wall bands, door frames, windows, roof planes, foreground trims, and occlusion overlays.
+- Maintain consistent material treatment for stone, timber, metal, roof tile, cloth, dirt, grass, mud, sand, snow, water, ash, lava, and interior surfaces.
+- Create environment variants that reduce repetition while preserving tile grammar, pathing clarity, and silhouette recognition.
+- Validate assets in assembled scenes with characters, VFX, HUD markers, common zoom levels, and lighting direction.
+
+# Behavior
+
+- Begin from the grid: footprint, anchor, elevation, layer, and collision expectations come before decoration.
+- Keep props and structures readable from the chosen isometric camera, with visible bases and clear contact shadows.
+- Slice tall or wide assets when one sprite would cause sorting problems around characters or walls.
+- Use value, shape, and material contrast to distinguish walkable floors, blockers, stairs, doors, hazards, ledges, and interactables.
+- Reuse biome recipes so new scenes inherit the same projection, scale, palette, lighting, and edge language.
+- Check transitions and seams in map layouts instead of judging isolated atlas cells.
+
+# Constraints
+
+- Do not invent a projection or scale that differs from `isometric-2-5d-art-director` guidance.
+- Do not ship structures, roofs, or tall props without documented anchors and draw-order expectations.
+- Do not create decorative variants that make pathing, collision, doorways, hazards, or elevation ambiguous.
+- Do not hide required tile edges under noisy textures or inconsistent shadows.
+- Do not mix hand-painted, pixel, pre-rendered, or flat styles in one environment kit unless the art director defines a unifying rule.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-art-director` for projection, scale, lighting, and scene grammar.
+- Partner with `tile-set-artist` for tile seams, terrain transitions, autotile masks, and atlas organization.
+- Partner with `pixel-artist` for character and creature readability against terrain.
+- Partner with `pre-rendered-2-5d-artist` when structures or props originate from 3D renders.
+- Partner with engineering roles when assets require custom sorting, roof fade, collision overlays, or map metadata.
+- Partner with `game-designer` to keep paths, blockers, doors, hazards, cover, elevation, and interactables visually fair.
+- Partner with `qa-engineer` to validate assembled maps, roof/wall occlusion, transition tiles, collision overlays, and readability at target zoom.
+- Partner with `frontend-developer` or `fullstack-engineer` when environment assets require loader metadata, atlas slicing, layer masks, or runtime sort keys.
+- Partner with `technical-writer` to document biome recipes, map-layer rules, and environment handoff assumptions.

--- a/.roles/arts/parallax-background-artist/ROLE.md
+++ b/.roles/arts/parallax-background-artist/ROLE.md
@@ -1,0 +1,52 @@
+---
+name: parallax-background-artist
+description: 2D background artist focused on layered parallax scenes, atmospheric depth, seamless scrolling, and game-readable foreground separation.
+aliases:
+  - parallax-background-artist
+  - parallax-artist
+  - background-layer-artist
+  - scrolling-background-artist
+  - atmospheric-background-artist
+category: arts
+color: blue
+vibe: Paints depth in layers that move with the camera instead of fighting it.
+---
+
+# Purpose
+
+Create layered 2D backgrounds for games that support parallax depth, seamless scrolling, atmosphere, camera readability, and foreground gameplay clarity.
+
+# Responsibilities
+
+- Design sky, far background, midground, near background, foreground, weather, atmosphere, and silhouette layers for side-view, top-down, and isometric-adjacent scenes.
+- Define layer order, scroll scale, repeat size, viewport coverage, tileability, alpha behavior, and compression expectations.
+- Produce loop-safe background textures and modular scenic elements that avoid visible seams during camera movement.
+- Maintain value separation so gameplay sprites, UI markers, hazards, and interactables remain readable over the background.
+- Specify whether layers are static, scrolling, repeating, animated, weather-driven, or camera-reactive.
+- Validate backgrounds across target aspect ratios, zoom levels, and camera speeds.
+
+# Behavior
+
+- Start from camera behavior: viewport, scroll direction, zoom, repeat needs, and foreground contrast determine layer design.
+- Use slower far layers and faster near layers to imply depth without distracting from gameplay.
+- Keep high-detail and high-contrast accents away from gameplay-critical focus zones unless they are intentional landmarks.
+- Design repeatable textures at or above viewport coverage when infinite scrolling is required.
+- Keep atmospheric effects consistent with the game's lighting direction, palette, time of day, and biome.
+- For isometric-first games, defer world projection and scale decisions to `isometric-2-5d-art-director`.
+
+# Constraints
+
+- Do not create backgrounds that obscure silhouettes, targeting indicators, pickups, text, or important UI overlays.
+- Do not rely on scaling tiny textures for pixel-perfect or crisp styles unless the project explicitly accepts blur.
+- Do not mix unmatched horizon lines, lighting directions, or perspective cues across layers.
+- Do not ship infinite-scroll backgrounds without seam and repeat-size checks.
+- Do not treat parallax as a substitute for map tiles or collision-bearing environment art.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-art-director` when parallax layers support an isometric scene or campaign map.
+- Partner with `isometric-2-5d-environment-artist` to align backgrounds with biomes, landmarks, and lighting.
+- Partner with `game-vfx-artist` for weather, fog, embers, dust, magical atmosphere, and animated environmental effects.
+- Partner with `game-designer` when background motion, landmarks, contrast, or foreground separation affects player navigation and focus.
+- Partner with engineering roles to confirm layer scroll scale, repeat behavior, memory budget, and camera constraints.
+- Partner with `qa-engineer` to verify seams, readability, and performance across resolutions.

--- a/.roles/arts/pixel-artist/ROLE.md
+++ b/.roles/arts/pixel-artist/ROLE.md
@@ -21,9 +21,11 @@ Create production-ready raster pixel art for games, with special attention to re
 - Create raster pixel-art characters, creatures, props, items, VFX, icons, UI embellishments, and sprite sheets.
 - Define palette ramps for light, shadow, material, outline, damage states, magic effects, and biome compatibility.
 - Produce animation sheet specifications with frame size, frame count, row order, anchor point, direction mapping, and transparency rules.
+- Support action-separated directional animation sheet packages when the project uses that convention, such as one PNG per action with consistent direction rows, frame columns, cell size, anchors, and transparent backgrounds.
 - Maintain strong silhouettes at gameplay scale before adding interior detail.
 - Ensure anatomy, gesture, weapon pose, wing pose, creature stance, and directional facing remain believable across all frames.
 - Create 4-direction, 8-direction, and action-state sprite sets when gameplay requires directional readability.
+- Create isometric sprite sets with stable foot anchors, readable facing, compatible tile scale, and consistent contact shadows when the project uses an isometric 2.5D camera.
 - Check sprite sheets in context against the actual camera, tile scale, background contrast, and animation timing.
 - Document asset contracts for frame grids, pivots, collision expectations, naming conventions, and export formats.
 
@@ -33,16 +35,20 @@ Create production-ready raster pixel art for games, with special attention to re
 - Prefer limited, intentional palettes with reusable ramps instead of noisy gradients or random color drift.
 - Treat animation as physical motion: feet should plant, wings should attach to shoulders, attacks should show anticipation/contact/recovery, and idle motion should not look like sliding.
 - Keep sprite sheets mechanically consistent: identical cell sizes, stable anchor points, predictable row order, and transparent backgrounds.
+- For 4-, 6-, 8-, 16-, or custom-direction sheets, document facing names, row order, angle assumptions, mirrored-frame policy, and action filenames before producing large batches.
 - Use in-game screenshots or renderer constraints to judge quality rather than judging sprites only in isolation.
+- For isometric scenes, validate sprites on angled floors, stairs, cliffs, doors, roofs, roads, foliage, water, and common prop occlusion cases.
+- Keep contact points stable across walk, idle, attack, hit, and death frames so movement and depth sorting do not appear to slide.
 - When generating or editing raster assets, separate concept exploration from final sheet production.
 - Preserve source licensing, attribution needs, and allowed derivative-use boundaries for any referenced pack.
-- Record reusable style rules so later generated assets can match the same palette, outline weight, material language, and animation cadence.
+- Record reusable style rules in host `STYLE.md` or a selected `.styles` template so later generated assets can match the same palette, outline weight, material language, and animation cadence.
 
 # Constraints
 
 - Do not produce vector-first final assets; use `css-vector-artist` for CSS, SVG, logo, and vector-native work.
 - Do not ship placeholder boxes, stick figures, flat emblems, or unreadable silhouettes as finished pixel art.
 - Do not mix incompatible pixel densities, camera angles, outline weights, or palette styles in one asset set.
+- Do not ship isometric sprites with drifting foot anchors, mismatched elevation scale, unclear facing, or shadows that contradict the scene lighting direction.
 - Do not change gameplay hitboxes, movement rules, or combat tuning unless explicitly asked; report when art and gameplay contracts disagree.
 - Do not rely on a single generated concept image as proof that a full sprite sheet is production-ready.
 - Do not accept frames with cropped limbs, floating wings, malformed anatomy, inconsistent facing, accidental text, watermarking, or broken transparency.
@@ -51,6 +57,9 @@ Create production-ready raster pixel art for games, with special attention to re
 # Collaboration
 
 - Partner with `tile-set-artist` to ensure sprites read clearly against biome tiles, roads, foliage, water, cliffs, interiors, and town surfaces.
+- Partner with `isometric-2-5d-art-director` for projection, scale, foot anchors, facing rules, and depth-sorting expectations in isometric games.
+- Partner with `isometric-2-5d-environment-artist` to test character and creature readability against structures, props, and elevation.
+- Partner with `game-designer` to align attack silhouettes, telegraphs, hit states, pickup states, and animation timing with gameplay intent.
 - Partner with `frontend-developer` or `fullstack-engineer` when assets need loader paths, atlas metadata, runtime anchors, or animation-state wiring.
 - Partner with `qa-engineer` to verify sprite sheets in-game across movement, combat, camera, UI overlays, and common backgrounds.
 - Partner with `generative-art-designer` when concept generation is useful, then convert acceptable concepts into sheet-safe raster production.

--- a/.roles/arts/pre-rendered-2-5d-artist/ROLE.md
+++ b/.roles/arts/pre-rendered-2-5d-artist/ROLE.md
@@ -1,0 +1,56 @@
+---
+name: pre-rendered-2-5d-artist
+description: Specialist for rendering 3D or high-detail source assets into 2D/2.5D sprites that match the target game camera, projection, and atlas pipeline.
+aliases:
+  - pre-rendered-2-5d-artist
+  - prerendered-2-5d-artist
+  - hd-2d-artist
+  - rendered-sprite-artist
+  - orthographic-render-artist
+  - 3d-to-2d-artist
+category: arts
+color: violet
+vibe: Converts depth-rich source art into disciplined 2D game assets.
+---
+
+# Purpose
+
+Create pre-rendered 2D and 2.5D game assets from 3D or high-detail source workflows while preserving the active isometric projection, scale, lighting, and runtime atlas constraints.
+
+# Responsibilities
+
+- Render characters, props, structures, terrain pieces, bosses, items, VFX cards, and scene elements into 2D sprite or atlas deliverables.
+- Match orthographic camera angle, focal assumptions, scale, shadow direction, material values, and alpha boundaries to the target art direction.
+- Produce multi-angle or directional sprite sets when gameplay requires facings, turnarounds, or rotation states.
+- Support 4-, 6-, 8-, 16-, or custom-direction render batches, and keep action-separated sheet dimensions, cell size, row order, and transparent output consistent across every action.
+- Document render settings, source-file assumptions, frame grids, pivots, shadows, normal/specular map needs, and export formats.
+- Reduce unnecessary transparent pixels, aliasing, compression artifacts, and inconsistent padding before atlas handoff.
+- Validate rendered assets in game-scale scenes, not only in the source 3D or painting tool.
+
+# Behavior
+
+- Treat the 2D target view as final authority. The source model may be 3D, but the delivered asset must read correctly in the game camera.
+- Lock camera, scale, lighting, and shadow before producing large batches.
+- Keep silhouettes readable after downscaling and compression.
+- Separate diffuse color, shadow, highlight, normal/specular, and mask needs when the runtime pipeline supports 2D lighting.
+- Prefer repeatable render presets so future batches match the same projection and material language.
+- Preserve source files or render notes when assets need later fixes or alternate facings.
+
+# Constraints
+
+- Do not deliver assets whose perspective, lens, shadow, or scale conflicts with the active `STYLE.md` contract or selected `.styles` templates.
+- Do not bake shadows or highlights in a way that contradicts runtime lighting unless the art director approves a fully baked look.
+- Do not leave cropped shadows, halos, background pixels, jagged alpha, or mismatched padding in final exports.
+- Do not assume a single rendered angle is enough when gameplay needs 4-direction, 8-direction, or state-specific readability.
+- Do not mix render batches with different cell sizes, direction row order, frame counts, or alpha/background assumptions unless the runtime manifest explicitly supports it.
+- Do not introduce heavy source workflows unless they reduce production risk or achieve a look impossible with direct 2D art.
+
+# Collaboration
+
+- Partner with `isometric-2-5d-art-director` to lock projection, camera, lighting, scale, and handoff rules.
+- Partner with `isometric-2-5d-environment-artist` for rendered structures, props, terrain modules, and scene composition.
+- Partner with `pixel-artist` when rendered outputs are converted into sprite sheets or need manual cleanup.
+- Partner with `game-vfx-artist` when flipbooks or impact effects are rendered from simulation tools.
+- Partner with `frontend-developer` or `fullstack-engineer` when runtime imports need atlas metadata, normal/specular maps, compression settings, or shader assumptions.
+- Partner with `qa-engineer` to validate rendered assets at gameplay scale with sorting, transparency, compression, and readability checks.
+- Partner with engineering roles when normal/specular maps, atlases, compression, or shader assumptions affect runtime behavior.

--- a/.roles/arts/tile-set-artist/ROLE.md
+++ b/.roles/arts/tile-set-artist/ROLE.md
@@ -20,6 +20,7 @@ Create coherent raster tileset systems for towns, cities, wilderness, dungeons, 
 
 - Design biome tilesets for land, water, roads, cliffs, shores, walls, floors, roofs, bridges, interiors, ruins, vegetation, and decorative statics.
 - Define tile contracts for dimensions, diamond masks or square masks, anchor points, elevation, transparency, collision, walkability, and render-layer expectations.
+- For isometric-first games, defer projection, elevation language, camera angle, scale, and draw-order grammar to `isometric-2-5d-art-director`.
 - Create transition sets for terrain blending: edges, corners, diagonals, shorelines, cliff seams, road joins, water borders, and biome-to-biome blends.
 - Produce variant tiles that reduce repetition while preserving recognizability and gameplay readability.
 - Establish material palettes for mud, moss, grass, sand, stone, timber, metal, roof tile, water, snow, ash, lava, and city paving.
@@ -30,6 +31,7 @@ Create coherent raster tileset systems for towns, cities, wilderness, dungeons, 
 # Behavior
 
 - Start from the terrain grammar: base tiles, transition tiles, feature tiles, statics, elevation, collision, and decoration.
+- In isometric maps, treat tile footprint, height unit, anchor, wall/roof layering, and object-base sorting as part of the tileset contract.
 - Treat seams as first-class quality gates; tiles must connect cleanly in every intended neighbor arrangement.
 - Preserve gameplay clarity: hazards, walkable ground, cover, no-shoot blockers, cliffs, doors, and interactables must be visually distinct.
 - Use consistent lighting direction, texture scale, outline strength, pixel density, and camera angle across all tiles in a biome.
@@ -43,6 +45,7 @@ Create coherent raster tileset systems for towns, cities, wilderness, dungeons, 
 - Do not create character, creature, boss, or animation sprite sheets as the primary deliverable; use `pixel-artist` for mobile sprites.
 - Do not produce vector-first final tiles; use `css-vector-artist` for vector-native art.
 - Do not ship tiles with broken seams, mismatched scale, inconsistent perspective, noisy readability, or unclear walkability.
+- Do not establish independent isometric projection rules when an isometric art director is active.
 - Do not hide collision or gameplay-important boundaries under decorative texture.
 - Do not mix incompatible biome palettes or lighting directions without a deliberate transition set.
 - Do not ignore asset licensing, attribution, derivative-use limits, or AI-generation restrictions for referenced packs.
@@ -51,6 +54,9 @@ Create coherent raster tileset systems for towns, cities, wilderness, dungeons, 
 # Collaboration
 
 - Partner with `pixel-artist` to test sprite readability against biome surfaces and environmental contrast.
+- Partner with `isometric-2-5d-art-director` to lock projection, elevation, sorting, and readability rules before expanding isometric tilesets.
+- Partner with `isometric-2-5d-environment-artist` on structures, props, roofs, cliffs, stairs, and assembled scene kits.
+- Partner with `game-designer` to make tile language communicate movement, collision, hazards, cover, objectives, and interactables fairly.
 - Partner with `frontend-developer`, `fullstack-engineer`, or renderer-focused engineering roles when tile metadata, atlas slicing, or map loaders need implementation.
 - Partner with `qa-engineer` to verify tiles in real maps, transition stress tests, collision overlays, and accessibility contrast checks.
 - Partner with `generative-art-designer` for biome mood boards and source-style exploration before producing sheet-safe tiles.

--- a/.roles/computer-science/frontend-developer/ROLE.md
+++ b/.roles/computer-science/frontend-developer/ROLE.md
@@ -59,7 +59,11 @@ You are **Frontend Developer**, an expert frontend developer who specializes in 
 - Test with real assistive technologies and diverse user scenarios
 
 ### Arts Consultation Triggers
+- Read active `STYLE.md` before implementing visual, HUD, icon, minimap, marker, generated-image, or game-art-heavy UI work.
 - Consult `css-vector-artist` when building custom icon packs, logo systems, SVG/CSS illustrations, or depth/elevation token standards.
+- Consult `isometric-2-5d-art-director` when HUD, minimap, marker, tooltip, selection, or targeting UI must stay readable over an isometric game view.
+- Consult `prepare-game-art-handoff` guidance when integrating sprites, atlases, VFX flipbooks, parallax layers, or generated assets into runtime loaders.
+- Verify directional animation sheets against their manifest before wiring runtime animations: cell size, row order, action filename, frame count, anchor, and transparent background.
 - Consult `generative-art-designer` when the feature needs model-generated concept art, hero imagery, or campaign visuals before UI implementation.
 - Convert approved generated concepts into production-ready vector/CSS assets with `css-vector-artist` before release.
 

--- a/.roles/computer-science/fullstack-engineer/ROLE.md
+++ b/.roles/computer-science/fullstack-engineer/ROLE.md
@@ -43,7 +43,10 @@ You are **Fullstack Engineer**, an end-to-end specialist who delivers complete, 
 ## Collaboration
 - Work well with `backend-architect` on service boundaries and data contracts.
 - Work well with `frontend-developer` on component architecture and state modeling.
+- Read active `STYLE.md` when implementing art-heavy flows, game UIs, asset loaders, sprite atlases, map renderers, generated images, or visual regression paths.
 - Consult `css-vector-artist` when features include custom icons, logos, or illustration systems that must ship as maintainable vector/CSS assets.
+- Consult `isometric-2-5d-art-director`, `tile-set-artist`, `pixel-artist`, or `game-vfx-artist` when runtime behavior depends on pivots, anchors, sorting layers, atlas metadata, animation state names, or gameplay readability.
+- For character animation sheets, preserve manifest-driven direction counts, action filenames, frame dimensions, row maps, anchors, and event timing through loaders, APIs, and tests.
 - Consult `generative-art-designer` when requirements include generated visual concepts; hand off approved concepts to `css-vector-artist` for production implementation.
 - Work well with `security-engineer` on authentication, authorization, and secure defaults.
 - Work well with `qa-engineer` on integration and regression coverage.

--- a/.roles/computer-science/game-designer/ROLE.md
+++ b/.roles/computer-science/game-designer/ROLE.md
@@ -25,6 +25,8 @@ Shape game features around proven industry game design principles so mechanics, 
 - Design encounter structure, boss patterns, combat roles, arena constraints, objective pressure, and failure/retry flow.
 - Create tuning frameworks for health, damage, stamina, cooldowns, economy, loot, upgrades, crafting, and progression gates.
 - Specify feedback requirements for animation, VFX, SFX, UI, camera, hit confirmation, telegraphs, affordances, and state changes.
+- Account for the active `STYLE.md` art contract when visual readability, isometric perspective, asset scale, or UI markers affect gameplay clarity.
+- Specify whether character movement and combat need 4, 6, 8, 16, or custom facings, and justify the direction count through player readability, aiming fidelity, content cost, and animation workload.
 - Identify whether a problem is design, implementation, art readability, UX, tuning, content, or production scope.
 - Document design intent, acceptance criteria, tuning ranges, edge cases, and test scenarios.
 
@@ -51,6 +53,8 @@ Shape game features around proven industry game design principles so mechanics, 
 # Collaboration
 
 - Partner with `pixel-artist` and `tile-set-artist` to ensure mechanics remain visually readable through sprites, tiles, telegraphs, and environments.
+- Partner with `isometric-2-5d-art-director` when movement, collision, cover, hazards, elevation, camera angle, or interactables depend on isometric visual grammar.
+- Partner with `game-vfx-artist`, `cutout-rig-animator`, and `css-vector-artist` when feedback timing, animation events, HUD markers, or state symbols are part of player comprehension.
 - Partner with `frontend-developer` or gameplay engineering roles to translate design intent into implementable systems and runtime feedback.
 - Partner with `qa-engineer` to create playtest scenarios, balance checks, regression cases, and fairness validation.
 - Partner with `project-manager` to scope design work into milestones, prototypes, tuning passes, and validation gates.

--- a/.roles/computer-science/qa-engineer/ROLE.md
+++ b/.roles/computer-science/qa-engineer/ROLE.md
@@ -52,6 +52,15 @@ Define and enforce a practical quality strategy so changes can ship with clear, 
   - cross-browser: targeted Chromium/Firefox/WebKit validation for high-risk flows
 - Integrate Playwright with CI gates and test reports so failures are visible and triage-ready.
 
+# Art And Game Asset Quality
+
+- Validate visual/game-art changes against active `STYLE.md` when art direction affects release quality.
+- For isometric games, test representative scenes for projection consistency, anchor stability, sorting, occlusion, roof/wall/floor layering, collision readability, and UI marker contrast.
+- Verify sprite sheets, VFX flipbooks, parallax layers, vector icons, and atlas exports in runtime context instead of relying only on isolated asset previews.
+- For directional animation sheet folders, verify consistent PNG dimensions, cell size, direction rows, frame columns, alpha channel, action filenames, and runtime row/action mappings before release.
+- Capture screenshots, traces, canvas checks, or annotated scene evidence for visual regressions and art handoff defects.
+- Treat broken pivots, drifting anchors, unreadable hazards, clipped sprites, broken seams, malformed text in art, and inaccessible contrast as release-relevant defects when they affect player comprehension.
+
 # Constraints
 
 - Do not treat "works on my machine" as valid release evidence.
@@ -67,6 +76,7 @@ Define and enforce a practical quality strategy so changes can ship with clear, 
 - Partner with feature owners early to define testable acceptance criteria and quality gates.
 - Work with `frontend-developer` and `fullstack-engineer` to ensure stable test hooks and accessible UI semantics for automation.
 - Coordinate with `css-vector-artist` and `generative-art-designer` when release quality depends on visual fidelity, text rendering quality, or art safety checks.
+- Coordinate with `isometric-2-5d-art-director`, `tile-set-artist`, `pixel-artist`, and `game-vfx-artist` when game-art readability, sorting, animation, or style-contract checks affect acceptance criteria.
 - Work with `backend-architect` and `senior-developer` on deterministic test data, contracts, and integration boundaries.
 - Work with `code-reviewer` on defect prevention and testability feedback during implementation, not only at release time.
 - Coordinate with `security-engineer` and `sre` for cross-functional release risk checks.

--- a/.roles/computer-science/software-architect/ROLE.md
+++ b/.roles/computer-science/software-architect/ROLE.md
@@ -23,6 +23,7 @@ Design software architectures that balance competing concerns:
 3. **Trade-off analysis** — Consistency vs availability, coupling vs duplication, simplicity vs flexibility
 4. **Technical decisions** — ADRs that capture context, options, and rationale
 5. **Evolution strategy** — How the system grows without rewrites
+6. **Visual/runtime contracts** — When a product includes game art or browser-rendered game experiences, account for `STYLE.md`, asset handoff metadata, atlas/runtime loaders, and visual QA boundaries as architecture inputs.
 
 ## Critical Rules
 1. **No architecture astronautics** — Every abstraction must justify its complexity

--- a/.roles/computer-science/technical-writer/ROLE.md
+++ b/.roles/computer-science/technical-writer/ROLE.md
@@ -21,6 +21,7 @@ You are a **Technical Writer**, a documentation specialist who bridges the gap b
 - Create API reference docs that are complete, accurate, and include working code examples
 - Build step-by-step tutorials that guide beginners from zero to working in under 15 minutes
 - Write conceptual guides that explain *why*, not just *how*
+- Document art style contracts, asset handoff metadata, atlas naming, isometric projection rules, and visual QA checklists when the repository includes game-art production workflows.
 
 ### Docs-as-Code Infrastructure
 - Set up documentation pipelines using Docusaurus, MkDocs, Sphinx, or VitePress

--- a/.styles/CEL_SHADED_COMIC.md
+++ b/.styles/CEL_SHADED_COMIC.md
@@ -1,0 +1,22 @@
+# CEL_SHADED_COMIC.md
+
+## Intent
+
+Create toon, comic, or cel-shaded game art with bold contours, controlled flat shading, graphic silhouettes, and readable action.
+
+## Production Rules
+
+- Define contour weight, interior line rules, shadow bands, highlight shapes, halftone/screen-tone use, and color blocking.
+- Keep light bands simple and intentional instead of soft painterly gradients.
+- Use graphic shape language for action, impact, expressions, and readable enemy intent.
+- Match outlines and shadow ramps across characters, props, environments, VFX, and UI callouts.
+
+## Acceptance Checks
+
+- Contours do not collapse at gameplay size.
+- Shadow bands reinforce form and gameplay clarity instead of adding noise.
+- Comic effects, text, or symbols are intentional, legible, and language-appropriate.
+
+## Role Fit
+
+Use with `illustrative-2d-artist`, `cutout-rig-animator`, `game-vfx-artist`, and `generative-art-designer`.

--- a/.styles/CUTOUT_RIGGED.md
+++ b/.styles/CUTOUT_RIGGED.md
@@ -1,0 +1,22 @@
+# CUTOUT_RIGGED.md
+
+## Intent
+
+Create segmented 2D characters, creatures, props, and bosses for puppet, cutout, or skeletal animation workflows.
+
+## Production Rules
+
+- Define root, hierarchy, pivots, rest pose, draw order, masks, attachment points, bone names, and export format.
+- Segment parts where rotation or deformation is needed; use replacement drawings for hands, feet, faces, weapons, and extreme poses.
+- Keep contact points stable and animation states named for runtime use.
+- Combine rigged animation with cel swaps or sprite frames when deformation alone is not enough.
+
+## Acceptance Checks
+
+- No drifting pivots, detached limbs, unstable anchors, or broken draw order.
+- Animation states document loop points, events, transitions, and gameplay timing.
+- Rigs validate at gameplay scale against collision, VFX, and facing expectations.
+
+## Role Fit
+
+Use with `cutout-rig-animator`, `illustrative-2d-artist`, `pixel-artist`, and engineering roles that integrate animation runtime.

--- a/.styles/DOODLE_SKETCH.md
+++ b/.styles/DOODLE_SKETCH.md
@@ -1,0 +1,22 @@
+# DOODLE_SKETCH.md
+
+## Intent
+
+Create playful sketch-like game art with intentionally imperfect linework while preserving animation and gameplay readability.
+
+## Production Rules
+
+- Define line wobble, sketch density, fill rules, animation jitter, texture, and cleanup thresholds.
+- Keep silhouettes recognizable despite loose drawing.
+- Use intentional imperfection; accidental anatomy errors, unreadable poses, and messy exports are not style.
+- Maintain consistent paper, ink, or sketch treatment across asset families.
+
+## Acceptance Checks
+
+- Assets remain readable at gameplay scale.
+- Sketch variation feels intentional and does not break animation continuity.
+- UI, text, and important symbols remain clean enough to read.
+
+## Role Fit
+
+Use with `illustrative-2d-artist`, `cutout-rig-animator`, and `generative-art-designer`.

--- a/.styles/FLAT_MINIMALIST.md
+++ b/.styles/FLAT_MINIMALIST.md
@@ -1,0 +1,22 @@
+# FLAT_MINIMALIST.md
+
+## Intent
+
+Create clean, low-clutter game art with simple shapes, flat colors, strong hierarchy, and fast readability.
+
+## Production Rules
+
+- Define shape grammar, semantic color roles, value tiers, stroke rules, spacing, and state language.
+- Make shape and value carry meaning before relying on hue.
+- Keep backgrounds quiet enough for characters, UI, markers, hazards, and text to remain legible.
+- Use restrained effects; gradients, shadows, and textures should be minimal and purposeful.
+
+## Acceptance Checks
+
+- Critical states are not distinguished by color alone.
+- Icons, pickups, hazards, and UI markers read on representative scenes.
+- The simple style communicates gameplay meaning without ambiguity.
+
+## Role Fit
+
+Use with `flat-minimalist-game-artist`, `css-vector-artist`, `frontend-developer`, and `qa-engineer`.

--- a/.styles/GAME_VFX.md
+++ b/.styles/GAME_VFX.md
@@ -1,0 +1,22 @@
+# GAME_VFX.md
+
+## Intent
+
+Create readable visual effects for combat, magic, weather, pickups, status changes, UI feedback, and environmental atmosphere.
+
+## Production Rules
+
+- Define effect intent, timing, origin, peak, dissipation, blend mode, draw order, lifetime, and gameplay meaning.
+- Use silhouettes, values, motion arcs, and timing before adding glow or particle density.
+- Export flipbooks with consistent frame sizes, transparent backgrounds, padding, and loop notes.
+- Keep VFX proportional to gameplay importance and runtime budget.
+
+## Acceptance Checks
+
+- Effects do not obscure hazards, hitboxes, targeting, text, objectives, or character intent.
+- One-shot and looping effects have documented frame/event timing.
+- Particle counts, texture size, overdraw, and blend modes fit the target platform.
+
+## Role Fit
+
+Use with `game-vfx-artist`, `pixel-artist`, `illustrative-2d-artist`, and animation roles.

--- a/.styles/GEOMETRIC_SHAPE.md
+++ b/.styles/GEOMETRIC_SHAPE.md
@@ -1,0 +1,22 @@
+# GEOMETRIC_SHAPE.md
+
+## Intent
+
+Create game art from clear geometric primitives, repeated motifs, and readable shape systems.
+
+## Production Rules
+
+- Define primitive families, proportions, spacing, rotation rules, corner radii, stroke widths, and state variants.
+- Use consistent shape symbolism for teams, hazards, pickups, projectiles, obstacles, and objectives.
+- Keep motion and collision visually aligned with the geometry players see.
+- Prefer crisp forms and high contrast over decorative detail.
+
+## Acceptance Checks
+
+- Shape language communicates gameplay meaning without labels.
+- Collision, movement, and visual footprint agree.
+- Visual hierarchy remains clear in dense scenes.
+
+## Role Fit
+
+Use with `flat-minimalist-game-artist`, `css-vector-artist`, `game-vfx-artist`, and UI roles.

--- a/.styles/HAND_DRAWN_ILLUSTRATIVE.md
+++ b/.styles/HAND_DRAWN_ILLUSTRATIVE.md
@@ -1,0 +1,22 @@
+# HAND_DRAWN_ILLUSTRATIVE.md
+
+## Intent
+
+Create handcrafted 2D game art with expressive linework, readable silhouettes, consistent rendering, and production-ready raster exports.
+
+## Production Rules
+
+- Define line quality, brush texture, value range, palette, material handling, lighting direction, and detail density.
+- Keep playable read first: pose, silhouette, facing, scale, and value hierarchy before surface detail.
+- Use turnaround, pose, and expression references when animation or directional consistency matters.
+- Separate concept art from final game exports with anchors, transparency, safe cropping, and scale notes.
+
+## Acceptance Checks
+
+- Assets read at gameplay size and on representative backgrounds.
+- Brush style, line weight, rendering detail, and lighting remain consistent across an asset family.
+- No unclear anatomy, accidental text, watermarking, or missing export metadata.
+
+## Role Fit
+
+Use with `illustrative-2d-artist`, `cutout-rig-animator`, `generative-art-designer`, and isometric roles when illustrated assets appear in the game view.

--- a/.styles/HD_2D.md
+++ b/.styles/HD_2D.md
@@ -1,0 +1,22 @@
+# HD_2D.md
+
+## Intent
+
+Combine high-detail 2D sprites with depth-rich scenes, lighting, post-processing, or 3D-like staging while preserving 2D gameplay readability.
+
+## Production Rules
+
+- Define how 2D sprites coexist with depth layers, lighting, shadows, camera movement, and environmental scale.
+- Keep sprite anchors and billboard behavior explicit when assets exist in a depth-staged world.
+- Use lighting and atmospheric effects to enhance depth without washing out silhouettes.
+- Preserve readable tactical space even when scenes use cinematic composition or heavy atmosphere.
+
+## Acceptance Checks
+
+- Characters and interactables remain readable over high-detail backgrounds.
+- Depth effects do not contradict movement, collision, sorting, or UI markers.
+- Lighting and post effects can be disabled or tuned without destroying core readability.
+
+## Role Fit
+
+Use with `isometric-2-5d-art-director`, `pre-rendered-2-5d-artist`, `illustrative-2d-artist`, and `game-vfx-artist`.

--- a/.styles/INDEX.md
+++ b/.styles/INDEX.md
@@ -1,0 +1,48 @@
+# Style Templates
+
+Available OpenCaw art style templates:
+
+- CEL_SHADED_COMIC
+- CUTOUT_RIGGED
+- DOODLE_SKETCH
+- FLAT_MINIMALIST
+- GAME_VFX
+- GEOMETRIC_SHAPE
+- HAND_DRAWN_ILLUSTRATIVE
+- HD_2D
+- ISOMETRIC_2_5D
+- LOW_POLY_2_5D
+- MONOCHROME_LIMITED_PALETTE
+- PAINTERLY_2D
+- PARALLAX_BACKGROUND
+- PIXEL_ART
+- PRE_RENDERED_2_5D
+- TACTICAL_UI_HUD
+- TILESET_ENVIRONMENT
+- VECTOR_UI
+
+Use one or more of these when generating `../STYLE.md` for a host repository.
+
+## Recommended Starting Points
+
+- Isometric tactics, town builders, ARPGs, and 2.5D exploration: `ISOMETRIC_2_5D`
+- Pixel games: `PIXEL_ART` plus `TILESET_ENVIRONMENT`
+- Hand-painted games: `HAND_DRAWN_ILLUSTRATIVE` or `PAINTERLY_2D`
+- UI-heavy games: `TACTICAL_UI_HUD` plus `VECTOR_UI`
+- Animation-heavy characters: `CUTOUT_RIGGED`
+- Sprite-rendered 3D pipelines: `PRE_RENDERED_2_5D` or `HD_2D`
+- Effects-heavy combat or magic: `GAME_VFX`
+
+## Research Basis
+
+- Unity 2D art style reference: https://docs.unity.cn/6000.0/Documentation/Manual/2d-game-art-syle-reference.html
+- Unity isometric tilemap guidance: https://docs.unity.cn/Manual/Tilemap-Isometric.html
+- Unity Sprite Atlas guidance: https://learn.unity.com/tutorial/introduction-to-the-sprite-atlas-2019-3
+- Godot parallax guidance: https://docs.godotengine.org/en/4.5/tutorials/2d/2d_parallax.html
+- Godot 2D lights and shadows: https://docs.godotengine.org/en/stable/tutorials/2d/2d_lights_and_shadows.html
+- Godot cutout and skeletal animation: https://docs.godotengine.org/en/stable/tutorials/animation/cutout_animation.html and https://docs.godotengine.org/en/stable/tutorials/animation/2d_skeletons.html
+- Godot 2D particle systems: https://docs.godotengine.org/en/latest/tutorials/2d/particle_systems_2d.html
+- Microsoft Xbox Accessibility Guideline 102: https://learn.microsoft.com/en-us/gaming/accessibility/xbox-accessibility-guidelines/102
+- Game Accessibility Guidelines contrast guidance: https://gameaccessibilityguidelines.com/provide-high-contrast-between-text-ui-and-background/
+- GameMaker 2D game art style guide: https://gamemaker.io/en/blog/2d-game-art-styles
+- Pixune 2D art style overview: https://pixune.com/blog/2d-art-styles/

--- a/.styles/ISOMETRIC_2_5D.md
+++ b/.styles/ISOMETRIC_2_5D.md
@@ -1,0 +1,28 @@
+# ISOMETRIC_2_5D.md
+
+This is the primary style template for isometric-first game art.
+
+## Intent
+
+Create a coherent 2.5D world using a fixed isometric or dimetric projection where 2D assets imply depth, elevation, occlusion, and tactical space.
+
+## Production Rules
+
+- Default to a 2:1 dimetric diamond for raster isometric art unless the project records a different projection in `STYLE.md`.
+- Lock tile width, tile depth, elevation step, camera angle, character height, door height, and prop footprints before production assets.
+- Use stable foot/contact anchors for characters and base anchors for props; sorting should follow gameplay contact points, not sprite centers.
+- Separate floor, wall, roof, prop, character, VFX, overlay, shadow, and UI-marker layers.
+- Slice tall assets when one sprite would break occlusion around walls, roofs, trees, cliffs, bridges, or doors.
+- Express elevation with consistent wall bands, stairs, shadows, cliff tiers, ramps, and contact points.
+- Keep walkable ground, blockers, doors, stairs, hazards, cover, objectives, pickups, and interactables visually distinct.
+
+## Acceptance Checks
+
+- Characters remain readable against roads, grass, water, cliffs, interiors, and high-detail props.
+- Depth sorting works in front of and behind tall props, walls, stairs, roofs, and foreground overlays.
+- Lighting direction, cast shadows, contact shadows, and value grouping agree across tiles, props, sprites, and VFX.
+- Atlas exports include transparent backgrounds, padding, pivots, anchors, layer notes, and collision/readability assumptions.
+
+## Role Fit
+
+Use with `isometric-2-5d-art-director`, `isometric-2-5d-environment-artist`, `tile-set-artist`, `pixel-artist`, `pre-rendered-2-5d-artist`, and `game-vfx-artist`.

--- a/.styles/LOW_POLY_2_5D.md
+++ b/.styles/LOW_POLY_2_5D.md
@@ -1,0 +1,22 @@
+# LOW_POLY_2_5D.md
+
+## Intent
+
+Create low-poly-inspired 2.5D art with simplified facets, bold shapes, efficient production, and clear depth.
+
+## Production Rules
+
+- Define facet size, edge treatment, palette, lighting direction, shadow style, and camera/projection behavior.
+- Keep forms simple enough to read after raster export or in orthographic view.
+- Use facets to clarify volume and material, not to add random noise.
+- Align 2D sprites, rendered props, and UI markers with the same simplified shape language.
+
+## Acceptance Checks
+
+- Facets and shadows support shape recognition at gameplay scale.
+- Projection, anchors, and sorting rules are explicit when used in a 2.5D scene.
+- Assets avoid inconsistent render angles or overly complex mesh detail.
+
+## Role Fit
+
+Use with `pre-rendered-2-5d-artist`, `isometric-2-5d-art-director`, `flat-minimalist-game-artist`, and environment roles.

--- a/.styles/MONOCHROME_LIMITED_PALETTE.md
+++ b/.styles/MONOCHROME_LIMITED_PALETTE.md
@@ -1,0 +1,22 @@
+# MONOCHROME_LIMITED_PALETTE.md
+
+## Intent
+
+Create strong mood and readability using one dominant color family, grayscale, or a tightly limited palette.
+
+## Production Rules
+
+- Define value tiers, accent colors, interactive colors, danger colors, disabled states, and background ranges.
+- Use value and shape to carry meaning before hue.
+- Reserve accent colors for high-importance gameplay information.
+- Avoid single-hue monotony by using texture, silhouette, composition, and value contrast deliberately.
+
+## Acceptance Checks
+
+- Important states remain distinguishable for color vision deficiency and low contrast conditions.
+- Gameplay-critical elements are visible on representative backgrounds.
+- Accent colors are used consistently and sparingly.
+
+## Role Fit
+
+Use with `flat-minimalist-game-artist`, `illustrative-2d-artist`, `css-vector-artist`, and `qa-engineer`.

--- a/.styles/PAINTERLY_2D.md
+++ b/.styles/PAINTERLY_2D.md
@@ -1,0 +1,22 @@
+# PAINTERLY_2D.md
+
+## Intent
+
+Create high-resolution painted 2D assets with controlled value, atmosphere, material texture, and game-scale readability.
+
+## Production Rules
+
+- Establish brush language, rendering finish, edge softness, palette, lighting temperature, and focal detail rules.
+- Keep high-detail rendering away from gameplay-critical boundaries unless it improves recognition.
+- Use value grouping and silhouette control to prevent painterly noise from reducing readability.
+- Export clean raster assets with documented anchors, transparent backgrounds, and atlas/compression expectations.
+
+## Acceptance Checks
+
+- Assets remain legible after downscaling, compression, and placement in game scenes.
+- Materials and lighting stay consistent across characters, props, structures, and backgrounds.
+- Detail does not hide collision, pathing, hazards, pickups, or objectives.
+
+## Role Fit
+
+Use with `illustrative-2d-artist`, `pre-rendered-2-5d-artist`, and `isometric-2-5d-art-director`.

--- a/.styles/PARALLAX_BACKGROUND.md
+++ b/.styles/PARALLAX_BACKGROUND.md
@@ -1,0 +1,22 @@
+# PARALLAX_BACKGROUND.md
+
+## Intent
+
+Create layered backgrounds that imply depth through independent scroll speeds, repeat behavior, atmosphere, and value separation.
+
+## Production Rules
+
+- Define background layers, order, scroll scale, repeat size, viewport coverage, loop behavior, and camera constraints.
+- Keep far layers slower and lower contrast than foreground gameplay elements.
+- Make infinite-scroll textures seamless and large enough for target viewports.
+- Keep detail density and contrast away from critical gameplay focus zones unless used as intentional landmarks.
+
+## Acceptance Checks
+
+- No visible seams, gaps, or mismatched horizon/perspective cues during camera movement.
+- Gameplay silhouettes, HUD, text, and markers remain readable over backgrounds.
+- Layers behave correctly across aspect ratios, zoom levels, and camera speeds.
+
+## Role Fit
+
+Use with `parallax-background-artist`, `game-vfx-artist`, and environment roles.

--- a/.styles/PIXEL_ART.md
+++ b/.styles/PIXEL_ART.md
@@ -1,0 +1,23 @@
+# PIXEL_ART.md
+
+## Intent
+
+Create crisp raster art with deliberate pixel placement, stable scale, readable silhouettes, and palette discipline.
+
+## Production Rules
+
+- Lock pixels-per-unit, camera scale, sprite dimensions, outline weight, and export scale before production.
+- Use limited palette ramps for light, shadow, material, damage, magic, biome compatibility, and UI states.
+- Keep sprites readable at gameplay scale before adding interior detail.
+- Maintain consistent frame sizes, anchor points, row order, transparency, and directional mapping in sprite sheets.
+- Use point filtering or equivalent crisp rendering unless the project explicitly chooses smoothed high-resolution raster art.
+
+## Acceptance Checks
+
+- No blurred upscale, inconsistent pixel density, cropped limbs, malformed anatomy, broken transparency, or accidental text.
+- Animation keeps planted feet, stable anchors, clear anticipation/contact/recovery, and consistent facing.
+- Sprites are validated on representative tiles, backgrounds, VFX, and UI overlays.
+
+## Role Fit
+
+Use with `pixel-artist`, `tile-set-artist`, `game-vfx-artist`, and isometric roles when pixel art is used in a 2.5D view.

--- a/.styles/PRE_RENDERED_2_5D.md
+++ b/.styles/PRE_RENDERED_2_5D.md
@@ -1,0 +1,22 @@
+# PRE_RENDERED_2_5D.md
+
+## Intent
+
+Create 2D or 2.5D sprites from 3D or high-detail source assets while matching the target game's camera, lighting, scale, and atlas pipeline.
+
+## Production Rules
+
+- Lock orthographic camera angle, render size, lighting, shadow, scale, material style, and transparent export settings before batching.
+- Preserve repeatable render presets and source notes for later facings or fixes.
+- Export directional sets when gameplay requires facing, rotation, or animation states.
+- Clean alpha, padding, halos, compression artifacts, and cropped shadows before handoff.
+
+## Acceptance Checks
+
+- Rendered assets match the project projection, value range, shadow direction, and sprite scale.
+- Final sprites read in assembled game scenes after downscaling and compression.
+- Source files or render settings are traceable enough for future revisions.
+
+## Role Fit
+
+Use with `pre-rendered-2-5d-artist`, `isometric-2-5d-art-director`, and `pixel-artist`.

--- a/.styles/TACTICAL_UI_HUD.md
+++ b/.styles/TACTICAL_UI_HUD.md
@@ -1,0 +1,22 @@
+# TACTICAL_UI_HUD.md
+
+## Intent
+
+Create HUD, minimap, selection, targeting, status, and tactical overlay art that remains readable during gameplay.
+
+## Production Rules
+
+- Define semantic states for selected, hover, disabled, danger, objective, ally, enemy, neutral, blocked, pathable, and interactable.
+- Use shape, iconography, outline, motion, and contrast so meaning does not rely on color alone.
+- Reserve strongest contrast and motion for immediate player decisions.
+- Test UI markers against dense terrain, VFX, characters, fog, shadows, and camera zooms.
+
+## Acceptance Checks
+
+- Text, reticles, minimap elements, targeting markers, and status icons meet contrast/readability expectations.
+- HUD and markers do not hide hazards, pickups, hit feedback, or movement cues.
+- Overlay scale and placement are stable across desktop/mobile viewports when relevant.
+
+## Role Fit
+
+Use with `css-vector-artist`, `flat-minimalist-game-artist`, `isometric-2-5d-art-director`, and `qa-engineer`.

--- a/.styles/TILESET_ENVIRONMENT.md
+++ b/.styles/TILESET_ENVIRONMENT.md
@@ -1,0 +1,22 @@
+# TILESET_ENVIRONMENT.md
+
+## Intent
+
+Create reusable terrain, biome, settlement, dungeon, and structure kits that assemble cleanly into readable maps.
+
+## Production Rules
+
+- Define tile dimensions, masks, anchors, collision hints, walkability, render layers, and atlas grouping.
+- Build base tiles, edge tiles, corner tiles, diagonals, transitions, feature tiles, statics, elevation pieces, and decorative variants.
+- Keep terrain grammar consistent across roads, water, cliffs, shores, walls, floors, roofs, bridges, interiors, and vegetation.
+- Use enough variants to reduce repetition without hiding navigation or gameplay boundaries.
+
+## Acceptance Checks
+
+- Seam tests cover every intended neighbor arrangement.
+- Walkable ground, blockers, hazards, cover, doors, stairs, ledges, and interactables are visually distinct.
+- Assembled maps preserve lighting direction, texture scale, palette, and character readability.
+
+## Role Fit
+
+Use with `tile-set-artist`, `isometric-2-5d-environment-artist`, and `isometric-2-5d-art-director`.

--- a/.styles/VECTOR_UI.md
+++ b/.styles/VECTOR_UI.md
@@ -1,0 +1,22 @@
+# VECTOR_UI.md
+
+## Intent
+
+Create scalable interface art, icons, logos, markers, and overlays using vector-native or CSS/SVG workflows.
+
+## Production Rules
+
+- Define viewBox sizes, clear space, stroke widths, radii, icon tiers, palette tokens, and depth/elevation tokens.
+- Design for common UI sizes first: 16, 20, 24, 32, 48, 64, and 128 pixels.
+- Use semantic CSS variables or equivalent tokens for portable implementation.
+- Preserve crisp edges, optical alignment, and contrast in light/dark contexts.
+
+## Acceptance Checks
+
+- Icons and markers remain readable on busy game scenes and UI surfaces.
+- Final core assets are vector-native, CSS/SVG, or exported from an approved vector source.
+- No bitmap-dependent effects are required for core marks or UI symbols.
+
+## Role Fit
+
+Use with `css-vector-artist`, `flat-minimalist-game-artist`, and frontend roles.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ After scaffold checks, review these host-repository files when they exist:
 - `../.ai/RULES.md`
 - `../.ai/DEBUG.md`
 - `../ARCHITECTURE.md`
+- `../STYLE.md`
 - `../.ai/tasks/TODO.md`
 - `../.ai/tasks/OPEN_ISSUES.md`
 
@@ -67,6 +68,32 @@ Architecture templates live in:
 ### When regenerating architecture later
 - Ask the user again which templates apply.
 - Regenerate `../ARCHITECTURE.md` with the same default read-directive mode unless inline output is explicitly requested.
+
+## Art style workflow
+The canonical art style contract for the host repository is:
+
+- `../STYLE.md`
+
+Style templates live in:
+
+- `./.styles/`
+
+### When `../STYLE.md` exists
+- Read it and follow it as the authoritative art style contract for visual, game-art, generated-image, UI-art, and asset-production work.
+
+### When `../STYLE.md` is missing
+- Ask the user which style templates in `./.styles/` apply to the repository, unless the user already named the desired style.
+- Support selecting multiple templates for mixed-style repositories.
+- After the user answers, generate `../STYLE.md` with `./commands/generate-style.sh "<STYLE1>" ["STYLE2" ...]`.
+- Default generation must use concise read directives (for example `Read \`./<mount>/.styles/ISOMETRIC_2_5D.md\` instructions`) instead of inlining template text.
+- Use `--inline` only when the user explicitly asks for fully embedded template content.
+- Validate generated or edited style contracts with `./commands/validate-style-contract.sh`.
+- Once generated, use `../STYLE.md` as the authoritative art style contract.
+
+### When regenerating style later
+- Ask the user again which style templates apply unless they already named the replacement style set.
+- Regenerate `../STYLE.md` with the same default read-directive mode unless inline output is explicitly requested.
+- Validate the regenerated contract with `./commands/validate-style-contract.sh`.
 
 ## Role casting
 
@@ -366,6 +393,7 @@ OpenCaw includes schema validation commands for roles, skills, and commands:
 - `./commands/validate-roles.sh`
 - `./commands/validate-skills.sh`
 - `./commands/validate-commands.sh`
+- `./commands/validate-styles.sh`
 - `./commands/validate-opencaw.sh`
 
 Use these when:

--- a/commands/SCHEMA.md
+++ b/commands/SCHEMA.md
@@ -153,5 +153,7 @@ Commands = execution layer
 Validation may be enforced with:
 
 - `./commands/validate-commands.sh`
+- `./commands/validate-styles.sh`
+- `./commands/validate-style-contract.sh`
 - `./commands/validate-cloud-preferences.sh`
 - `./commands/validate-opencaw.sh`

--- a/commands/generate-style.sh
+++ b/commands/generate-style.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/generate-style.sh [--inline] "<STYLE1>" ["STYLE2" ...]
+
+Defaults to concise link-based output in ../STYLE.md.
+Use --inline to embed full style template contents.
+EOF
+}
+
+mode='link'
+styles=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --inline)
+      mode='inline'
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --)
+      shift
+      while [[ $# -gt 0 ]]; do
+        styles+=("$1")
+        shift
+      done
+      ;;
+    -*)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+    *)
+      styles+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "${#styles[@]}" -eq 0 ]]; then
+  usage >&2
+  exit 1
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+opencaw_root="$(cd "$script_dir/.." && pwd)"
+host_root="$(cd "$opencaw_root/.." && pwd)"
+mount_dir_name="$(basename "$opencaw_root")"
+mount_path_from_host="./${mount_dir_name}"
+style_target="$host_root/STYLE.md"
+
+selected=()
+for name in "${styles[@]}"; do
+  normalized_name="${name//-/_}"
+  normalized_name="${normalized_name// /_}"
+  upper_name="${normalized_name^^}"
+  template_path="$opencaw_root/.styles/${upper_name}.md"
+  if [[ ! -f "$template_path" ]]; then
+    echo "Missing style template: $template_path" >&2
+    exit 1
+  fi
+  selected+=("$upper_name")
+done
+
+{
+  echo "# STYLE.md"
+  echo
+  echo "This file is the canonical art style contract for this repository."
+  echo
+  echo "Generated from OpenCaw style templates:"
+  for name in "${selected[@]}"; do
+    echo "- $name"
+  done
+  echo
+  echo "---"
+  echo
+
+  if [[ "$mode" == 'link' ]]; then
+    echo "This document intentionally stays concise by referencing selected templates."
+    echo
+    echo "## Read Template Instructions"
+    echo
+    for name in "${selected[@]}"; do
+      echo "Read \`${mount_path_from_host}/.styles/${name}.md\` instructions"
+    done
+    echo
+    echo "Add repository-specific art style instructions below these read directives."
+  else
+    echo "## Inlined Templates"
+    echo
+    for name in "${selected[@]}"; do
+      template_path="$opencaw_root/.styles/${name}.md"
+      echo "<!-- BEGIN TEMPLATE: ${name} -->"
+      echo
+      cat "$template_path"
+      echo
+      echo "<!-- END TEMPLATE: ${name} -->"
+      echo
+      echo "---"
+      echo
+    done
+  fi
+} > "$style_target"
+
+echo "Wrote $style_target"
+if [[ "$mode" == 'link' ]]; then
+  echo "Mode: link (default)."
+else
+  echo "Mode: inline."
+fi

--- a/commands/inspect-animation-sheet-folder.sh
+++ b/commands/inspect-animation-sheet-folder.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+folder="${1:-.}"
+cell_size="${2:-128}"
+
+if [[ ! -d "$folder" ]]; then
+  echo "Animation sheet folder not found: $folder" >&2
+  exit 1
+fi
+
+if [[ ! "$cell_size" =~ ^[0-9]+$ || "$cell_size" -le 0 ]]; then
+  echo "Cell size must be a positive integer: $cell_size" >&2
+  exit 1
+fi
+
+python_cmd=""
+for candidate in python3 python python.exe py; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    python_cmd="$candidate"
+    break
+  fi
+done
+
+if [[ -z "$python_cmd" ]]; then
+  echo "Python is required to inspect PNG headers, but no Python executable was found." >&2
+  exit 1
+fi
+
+"$python_cmd" - "$folder" "$cell_size" <<'PY'
+from __future__ import annotations
+
+import struct
+import sys
+from collections import Counter
+from pathlib import Path
+
+folder = Path(sys.argv[1])
+cell_size = int(sys.argv[2])
+png_signature = b"\x89PNG\r\n\x1a\n"
+
+def read_png_info(path: Path):
+    with path.open("rb") as fh:
+        signature = fh.read(8)
+        if signature != png_signature:
+            raise ValueError("not a PNG file")
+        length = struct.unpack(">I", fh.read(4))[0]
+        chunk_type = fh.read(4)
+        if chunk_type != b"IHDR" or length < 13:
+            raise ValueError("missing IHDR")
+        data = fh.read(length)
+        width, height, bit_depth, color_type = struct.unpack(">IIBB", data[:10])
+        has_alpha = color_type in (4, 6)
+        return width, height, bit_depth, color_type, has_alpha
+
+files = sorted(folder.glob("*.png"))
+if not files:
+    print(f"No PNG animation sheets found under: {folder}")
+    sys.exit(0)
+
+layouts = Counter()
+status = 0
+
+print(f"Animation sheet inspection: {folder}")
+print(f"Expected cell size: {cell_size}x{cell_size}")
+print()
+print("| File | Size | Grid | Alpha | Notes |")
+print("| --- | --- | --- | --- | --- |")
+
+for path in files:
+    try:
+        width, height, bit_depth, color_type, has_alpha = read_png_info(path)
+    except Exception as exc:
+        print(f"| {path.name} | unknown | unknown | unknown | {exc} |")
+        status = 1
+        continue
+
+    notes = []
+    if width % cell_size != 0 or height % cell_size != 0:
+        notes.append("not divisible by cell size")
+        status = 1
+
+    columns = width // cell_size if width % cell_size == 0 else "custom"
+    rows = height // cell_size if height % cell_size == 0 else "custom"
+    if isinstance(columns, int) and isinstance(rows, int):
+        layouts[(columns, rows)] += 1
+
+    if not has_alpha:
+        notes.append("no alpha channel")
+
+    note_text = ", ".join(notes) if notes else "ok"
+    print(f"| {path.name} | {width}x{height} | {columns}x{rows} | {has_alpha} | {note_text} |")
+
+print()
+if layouts:
+    common = ", ".join(f"{cols}x{rows} ({count})" for (cols, rows), count in layouts.most_common())
+    print(f"Detected grids: {common}")
+
+if len(layouts) == 1:
+    (columns, rows), count = next(iter(layouts.items()))
+    print(f"Common profile: {columns} frame columns x {rows} direction/action rows across {count} sheet(s).")
+
+sys.exit(status)
+PY

--- a/commands/print-directional-animation-sheet-template.sh
+++ b/commands/print-directional-animation-sheet-template.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+character_name="${1:-character}"
+direction_count="${2:-8}"
+frames_per_action="${3:-15}"
+cell_size="${4:-128}"
+layout_profile="${5:-action-separated}"
+
+case "$direction_count" in
+  4)
+    directions="north east south west"
+    ;;
+  6)
+    directions="north north-east south-east south south-west north-west"
+    ;;
+  8)
+    directions="north north-east east south-east south south-west west north-west"
+    ;;
+  16)
+    directions="north north-north-east north-east east-north-east east east-south-east south-east south-south-east south south-south-west south-west west-south-west west west-north-west north-west north-north-west"
+    ;;
+  *)
+    directions="custom-direction-1 custom-direction-2 custom-direction-3"
+    ;;
+esac
+
+if [[ "$direction_count" =~ ^[0-9]+$ && "$frames_per_action" =~ ^[0-9]+$ && "$cell_size" =~ ^[0-9]+$ ]]; then
+  sheet_width=$((frames_per_action * cell_size))
+  sheet_height=$((direction_count * cell_size))
+else
+  sheet_width="custom"
+  sheet_height="custom"
+fi
+
+cat <<EOF
+# Directional Animation Sheet Plan: ${character_name}
+
+## Summary
+- Active STYLE.md templates:
+- Direction count: ${direction_count}
+- Directions: ${directions}
+- Frames per action: ${frames_per_action}
+- Cell size: ${cell_size}x${cell_size}
+- Sheet dimensions: ${sheet_width}x${sheet_height}
+- Packaging: ${layout_profile}
+- Anchor/contact point:
+- Source path:
+- Runtime export path:
+- Target engine/runtime:
+
+## Sky-Knight-Compatible Defaults
+Use this profile when the project wants sheets like assets/sky-knight.
+
+- one action per PNG
+- 8 direction rows
+- 15 frame columns
+- 128x128 cells
+- 1920x1024 sheet size
+- transparent PNG background
+- kebab-case action filenames
+
+## Sheet Layout
+| Field | Value |
+| --- | --- |
+| row_order | direction-first |
+| column_order | frame sequence |
+| row_count | ${direction_count} |
+| column_count | ${frames_per_action} |
+| transparent_padding |  |
+| atlas_padding |  |
+| pivot |  |
+| foot_anchor |  |
+| shadow_layer |  |
+| equipment_layers |  |
+| naming_pattern |  |
+
+## Action States
+| Action | Frames | Frame Duration | Loop | Event Frames | Notes |
+| --- | --- | --- | --- | --- | --- |
+| idle |  |  | yes |  |  |
+| walk |  |  | yes | footstep |  |
+| run |  |  | yes | footstep |  |
+| attack |  |  | no | anticipation, hit, recovery |  |
+| cast |  |  | no | cast_start, release |  |
+| hit |  |  | no | impact |  |
+| death |  |  | no | death_end |  |
+| interact |  |  | no | interact |  |
+
+## Action Files
+Use one row set per direction inside each action file when using action-separated sheets.
+
+- idle.png
+- walk.png
+- run.png
+- run-backwards.png
+- strafe-left.png
+- strafe-right.png
+- crouch-idle.png
+- crouch-run.png
+- melee.png
+- melee-2.png
+- melee-run.png
+- melee-spin.png
+- kick.png
+- pummel.png
+- cast-spell.png
+- shield-block-start.png
+- shield-block-mid.png
+- take-damage.png
+- die.png
+- slide-start.png
+- slide.png
+- slide-end.png
+- rolling.png
+- front-flip.png
+- 180-turn.png
+- unsheath-sword.png
+- special-1.png
+- special-2.png
+
+## Isometric Fields
+- projection:
+- tile_scale:
+- elevation_step:
+- facing_angle_policy:
+- mirrored_frames_allowed:
+- depth_sort_contact_point:
+- contact_shadow_policy:
+
+## Runtime Metadata
+- animation_names:
+- direction_to_row_map:
+- action_to_row_map:
+- frame_rate:
+- hitbox_policy:
+- hurtbox_policy:
+- attachment_points:
+- VFX_spawn_points:
+
+## Validation
+- anchor stability:
+- facing readability:
+- silhouette check:
+- animation timing check:
+- sorting check:
+- terrain/background contrast check:
+- UI overlay readability check:
+- style contract check:
+- licensing/source check:
+EOF

--- a/commands/print-game-art-handoff-template.sh
+++ b/commands/print-game-art-handoff-template.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+asset_type="${1:-game-art-asset}"
+engine="${2:-runtime-engine}"
+
+cat <<EOF
+# Game Art Handoff: ${asset_type}
+
+## Summary
+- Owner role:
+- Target engine/runtime: ${engine}
+- Target scene/feature:
+- Active STYLE.md templates:
+- Source asset path:
+- Runtime export path:
+
+## Asset Metadata
+| Field | Value |
+| --- | --- |
+| asset_id |  |
+| asset_type | ${asset_type} |
+| dimensions |  |
+| frame_grid |  |
+| atlas_key |  |
+| padding |  |
+| pivot |  |
+| anchor/contact_point |  |
+| sorting_layer/depth_key |  |
+| collision_hint |  |
+| animation_names |  |
+| loop_rules |  |
+| compression/export_format |  |
+| license/source |  |
+
+## Isometric Fields
+Complete when the project uses an isometric or 2.5D style.
+
+- projection:
+- tile_width_depth:
+- elevation_step:
+- footprint:
+- wall_floor_roof_layers:
+- occlusion_strategy:
+- walkability_notes:
+
+## Validation
+- STYLE.md checked:
+- transparency/background checked:
+- readability checked in scene:
+- seams or loop checked:
+- animation playback checked:
+- sorting/occlusion checked:
+- contrast/accessibility checked:
+- performance budget checked:
+- licensing checked:
+
+## Downstream Responsibilities
+- art:
+- game design:
+- engineering:
+- QA:
+- documentation:
+EOF

--- a/commands/print-isometric-production-checklist.sh
+++ b/commands/print-isometric-production-checklist.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+asset_type="${1:-isometric-asset}"
+
+cat <<EOF
+Isometric production checklist: ${asset_type}
+------------------------------------------
+Use this before approving isometric or 2.5D game art.
+
+style_contract_checked=false
+projection_locked=false
+tile_width_depth_documented=false
+elevation_step_documented=false
+camera_angle_documented=false
+lighting_direction_consistent=false
+
+anchors
+- feet_or_base_anchor_defined=false
+- pivot_exported=false
+- contact_shadow_consistent=false
+- prop_footprint_documented=false
+
+layers_and_sorting
+- floor_wall_roof_separated=false
+- tall_props_sliced_when_needed=false
+- occlusion_strategy_documented=false
+- sorting_layer_or_depth_key_defined=false
+- foreground_overlay_policy_defined=false
+
+gameplay_readability
+- walkable_ground_distinct=false
+- blockers_distinct=false
+- hazards_distinct=false
+- doors_stairs_cover_interactables_distinct=false
+- ui_markers_readable_over_asset=false
+- character_readability_checked=false
+
+runtime_handoff
+- atlas_padding_defined=false
+- transparent_background_ok=false
+- collision_or_navigation_hints_documented=false
+- engine_loader_assumptions_documented=false
+- qa_scene_context_identified=false
+EOF
+
+echo
+echo "Fail the asset if projection, anchors, sorting, or gameplay readability are unresolved."

--- a/commands/print-tileset-sheet-template.sh
+++ b/commands/print-tileset-sheet-template.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tileset_name="${1:-environment-tileset}"
+orientation="${2:-isometric}"
+
+cat <<EOF
+# Tileset Sheet Plan: ${tileset_name}
+
+## Summary
+- Active STYLE.md templates:
+- Orientation: ${orientation}
+- Tile size:
+- Elevation step:
+- Atlas size target:
+- Source path:
+- Runtime export path:
+- Target engine/runtime:
+
+## Tile Families
+| Family | Required Tiles | Notes |
+| --- | --- | --- |
+| base terrain | center, variants |  |
+| terrain transitions | edges, corners, inner corners, diagonals |  |
+| roads/paths | straight, corner, tee, cross, end caps |  |
+| water/shore | water, shore edges, foam, deep/shallow variants |  |
+| cliffs/elevation | wall bands, ledges, ramps, stairs |  |
+| structures | floors, walls, doors, windows, roofs |  |
+| vegetation/props | small, medium, tall, sliced variants |  |
+| hazards/objectives | hazard, pickup, interactable, objective |  |
+
+## Metadata
+| Field | Value |
+| --- | --- |
+| tile_width |  |
+| tile_height |  |
+| grid_orientation | ${orientation} |
+| collision_property |  |
+| walkability_property |  |
+| elevation_property |  |
+| biome_property |  |
+| atlas_padding |  |
+| naming_pattern |  |
+
+## Isometric Fields
+- projection:
+- footprint:
+- base_anchor:
+- wall_floor_roof_layer_policy:
+- depth_sort_key:
+- roof_or_tall_prop_slicing:
+
+## Validation
+- seam stress test:
+- transition coverage:
+- repeated-pattern check:
+- collision overlay check:
+- character readability check:
+- UI marker readability check:
+- style contract check:
+- licensing/source check:
+EOF

--- a/commands/validate-opencaw.sh
+++ b/commands/validate-opencaw.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ./commands/validate-roles.sh
 ./commands/validate-skills.sh
 ./commands/validate-commands.sh
+./commands/validate-styles.sh
 ./commands/validate-role-language-alignment.sh
 ./commands/validate-cloud-preferences.sh
 

--- a/commands/validate-style-contract.sh
+++ b/commands/validate-style-contract.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./commands/validate-style-contract.sh [STYLE.md]
+
+Validates that a host STYLE.md references existing OpenCaw .styles templates.
+Defaults to ../STYLE.md when run from the mounted OpenCaw directory.
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+opencaw_root="$(cd "$script_dir/.." && pwd)"
+host_root="$(cd "$opencaw_root/.." && pwd)"
+styles_dir="$opencaw_root/.styles"
+index_file="$styles_dir/INDEX.md"
+style_file="${1:-$host_root/STYLE.md}"
+
+if [[ ! -f "$style_file" ]]; then
+  echo "Missing STYLE.md: $style_file" >&2
+  exit 1
+fi
+
+if [[ ! -d "$styles_dir" ]]; then
+  echo "Missing styles directory: $styles_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$index_file" ]]; then
+  echo "Missing styles index: $index_file" >&2
+  exit 1
+fi
+
+status=0
+
+if ! grep -q '^# STYLE\.md$' "$style_file"; then
+  echo "STYLE.md is missing the expected top-level heading." >&2
+  status=1
+fi
+
+mapfile -t selected_styles < <(
+  awk '
+    /^Generated from OpenCaw style templates:/ { in_list=1; next }
+    /^---$/ { in_list=0 }
+    in_list && /^- / {
+      sub(/^- /, "")
+      gsub(/\r$/, "")
+      print
+    }
+  ' "$style_file"
+)
+
+if [[ ${#selected_styles[@]} -eq 0 ]]; then
+  echo "STYLE.md does not list any generated OpenCaw style templates." >&2
+  status=1
+fi
+
+for style_name in "${selected_styles[@]}"; do
+  template_path="$styles_dir/${style_name}.md"
+  if [[ ! "$style_name" =~ ^[A-Z0-9]+(_[A-Z0-9]+)*$ ]]; then
+    echo "Invalid style template name in STYLE.md: $style_name" >&2
+    status=1
+    continue
+  fi
+
+  if [[ ! -f "$template_path" ]]; then
+    echo "Missing referenced style template: $template_path" >&2
+    status=1
+  fi
+
+  if ! grep -q -- "- ${style_name}" "$index_file"; then
+    echo "Referenced style template is not listed in .styles/INDEX.md: $style_name" >&2
+    status=1
+  fi
+done
+
+if grep -q '^This document intentionally stays concise by referencing selected templates\.$' "$style_file"; then
+  for style_name in "${selected_styles[@]}"; do
+    if ! grep -q "\.styles/${style_name}\.md" "$style_file"; then
+      echo "Link-mode STYLE.md is missing a read directive for: $style_name" >&2
+      status=1
+    fi
+  done
+fi
+
+mapfile -t read_directives < <(
+  grep -Eo '\.styles/[A-Z0-9_]+\.md' "$style_file" | sed 's#^.styles/##; s#\.md$##' | sort -u
+)
+
+for directive_style in "${read_directives[@]}"; do
+  if [[ ! -f "$styles_dir/${directive_style}.md" ]]; then
+    echo "STYLE.md read directive points to a missing style template: $directive_style" >&2
+    status=1
+  fi
+done
+
+if [[ $status -eq 0 ]]; then
+  echo "Style contract validation passed."
+  printf 'Referenced styles:'
+  for style_name in "${selected_styles[@]}"; do
+    printf ' %s' "$style_name"
+  done
+  printf '\n'
+fi
+
+exit $status

--- a/commands/validate-styles.sh
+++ b/commands/validate-styles.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+styles_dir="./.styles"
+index_file="$styles_dir/INDEX.md"
+
+if [[ ! -d "$styles_dir" ]]; then
+  echo "Missing styles directory: $styles_dir" >&2
+  exit 1
+fi
+
+if [[ ! -f "$index_file" ]]; then
+  echo "Missing styles index: $index_file" >&2
+  exit 1
+fi
+
+status=0
+style_count=0
+
+while IFS= read -r -d '' style_md; do
+  file_name="$(basename "$style_md")"
+
+  if [[ "$file_name" == "INDEX.md" ]]; then
+    continue
+  fi
+
+  style_count=$((style_count + 1))
+  style_name="${file_name%.md}"
+
+  if [[ ! "$file_name" =~ ^[A-Z0-9]+(_[A-Z0-9]+)*\.md$ ]]; then
+    echo "Invalid style template name: $file_name" >&2
+    status=1
+  fi
+
+  if ! grep -q "^# ${style_name}\\.md" "$style_md"; then
+    echo "Missing matching top-level heading in $style_md" >&2
+    status=1
+  fi
+
+  for section in "## Intent" "## Production Rules" "## Acceptance Checks" "## Role Fit"; do
+    if ! grep -q "^${section}" "$style_md"; then
+      echo "Missing required section ($section) in $style_md" >&2
+      status=1
+    fi
+  done
+
+  if ! grep -q -- "- ${style_name}" "$index_file"; then
+    echo "Style template not listed in INDEX.md: $style_name" >&2
+    status=1
+  fi
+done < <(find "$styles_dir" -maxdepth 1 -type f -name "*.md" -print0)
+
+if [[ $style_count -eq 0 ]]; then
+  echo "No style templates found under $styles_dir." >&2
+  status=1
+fi
+
+if [[ $status -eq 0 ]]; then
+  echo "Styles validation passed."
+fi
+
+exit $status

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -40,6 +40,7 @@ Curated reusable skills included in OpenCaw.
 ## Architecture And Integration
 
 - `generate-architecture` - Generate `ARCHITECTURE.md` from selected templates.
+- `generate-style` - Generate `STYLE.md` from selected art style templates.
 - `apim-change-review` - Review Azure API Management changes for compatibility and risk.
 - `azure-settings-checklist` - Validate required Azure app settings and environment assumptions.
 - `function-app-checklist` - Validate Function App operational and deployment expectations.
@@ -58,7 +59,11 @@ Curated reusable skills included in OpenCaw.
 - `playwright-test-refinement` - Diagnose, rerun, and stabilize Playwright tests.
 - `playwright-reporting` - Generate non-interactive Playwright evidence reports from JSON results and artifacts.
 
-## Art Safety
+## Art Production
 
+- `maintain-art-style-contract` - Maintain, generate, or validate `STYLE.md` against selected `.styles` templates.
+- `review-isometric-production` - Review isometric art for projection, anchors, depth sorting, occlusion, and gameplay readability.
+- `prepare-game-art-handoff` - Prepare game art assets for engine/runtime handoff with metadata and validation checks.
+- `create-game-art-sheets` - Plan tilesets, environment sheets, prop atlases, and directional animation sheets.
 - `iterate-art-to-sanity` - Iterate generated art until sanity checks pass.
 - `enforce-art-language-safety` - Enforce language and visual safety constraints for generated art.

--- a/skills/create-game-art-sheets/SKILL.md
+++ b/skills/create-game-art-sheets/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: create-game-art-sheets
+description: Plan and specify production-ready game art sheets, including environment tilesets, biome/terrain sets, autotile sets, prop atlases, and directional character animation sheets with 4, 6, 8, 16, or custom facing counts. Use when art roles need to create tilesets or sprite animation sets before implementation handoff.
+---
+
+## When to use
+Use when creating or reviewing tilesets, environment sets, prop sheets, character sprite sheets, creature animation sheets, equipment overlays, directional attack sets, or isometric movement/animation sheets.
+
+## Workflow
+1. Read `../STYLE.md` and the relevant `.styles` templates before planning the sheet.
+2. Decide whether the deliverable is a tileset, prop/object atlas, directional animation sheet, VFX sheet, or mixed package.
+3. For tilesets, define tile dimensions, grid orientation, terrain families, transitions, variants, collision/walkability metadata, elevation rules, and atlas grouping.
+4. For animation sheets, choose between one-action-per-file sheets, one combined character atlas, equipment overlay sheets, or engine-native atlas packing.
+5. For animation sheets, define direction count, facing names, frame size, anchor/contact point, direction rows, frame columns, action file names, loop rules, timing, and gameplay events.
+6. When a local sample exists, inspect it and follow its reusable layout conventions unless the user asks to change them.
+7. For isometric sheets, include projection, tile footprint, elevation unit, stable foot anchors, draw-order expectations, contact shadows, and readable facings.
+8. Produce a manifest-ready contract before final art creation so engineering, design, QA, and documentation can validate the same assumptions.
+9. Pair this skill with `prepare-game-art-handoff` when the sheet is ready for runtime integration.
+
+## Sample-Driven Sheet Profile
+When the host repository contains a sample like `assets/sky-knight`, use it as a local style/layout reference after inspection:
+
+- one action per PNG file
+- kebab-case action names such as `idle.png`, `run.png`, `cast-spell.png`, `take-damage.png`, and `shield-block-start.png`
+- 8 direction rows
+- 15 frame columns per action
+- 128x128 frame cells
+- 1920x1024 total sheet dimensions
+- transparent PNG background
+- stable anchor/contact point across all actions and facings
+
+Do not hard-code this profile for every project. Treat it as the preferred local convention only when the user provides or selects it.
+
+## Direction Sets
+- 4-direction: north, east, south, west; use for simple top-down or grid movement.
+- 6-direction: useful for hex grids, stylized tactical games, or constrained facings; document exact facing angles.
+- 8-direction: common for top-down/isometric movement; include cardinal and diagonal facings.
+- 16-direction: use only when rotation fidelity, aiming, vehicles, bosses, or high-resolution facings justify the asset cost.
+- Custom direction counts must document angle degrees, row order, mirrored frames, and whether mirroring is allowed.
+
+## Tileset Contract
+- tile size and orientation
+- base terrain tiles
+- edge, corner, inner-corner, diagonal, cliff, shoreline, road, stair, wall, roof, and water transitions
+- biome variants and decoration frequency
+- walkable, blocker, hazard, cover, interactable, objective, and spawn metadata
+- atlas padding, naming, tile IDs, and source/runtime paths
+- seam stress-test layouts
+
+## Animation Contract
+- entity scale, frame size, transparent padding, and anchor point
+- direction count and row order
+- sheet packaging: one action per file or combined atlas
+- action filename list and kebab-case naming
+- action states such as idle, walk, run, attack, cast, hit, death, interact, emote, mount, swim, or fly
+- frames per action, frame duration, loop mode, cancel/event markers, and hit/contact frames
+- equipment, shadow, VFX, and attachment layers
+- collision/hitbox assumptions and runtime animation names
+
+## Output
+- selected sheet type and active style templates
+- tile or frame dimensions
+- row/column layout and naming convention
+- direction/facing list when applicable
+- required variants and action states
+- atlas and metadata fields
+- validation checks for seams, anchors, sorting, readability, animation timing, and licensing
+
+## Commands
+- `./commands/print-tileset-sheet-template.sh [tileset-name] [orientation]`
+- `./commands/print-directional-animation-sheet-template.sh [character-name] [direction-count] [frames-per-action] [cell-size]`
+- `./commands/inspect-animation-sheet-folder.sh [folder] [cell-size]`
+- `./commands/print-game-art-handoff-template.sh [asset-type] [engine]`
+- `./commands/print-isometric-production-checklist.sh [asset-type]`

--- a/skills/create-game-art-sheets/agents/openai.yaml
+++ b/skills/create-game-art-sheets/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Create Game Art Sheets"
+  short_description: "Plan tilesets and directional character animation sheets."
+  default_prompt: "Plan a production-ready tileset or directional animation sheet with frame, atlas, anchor, and validation metadata."

--- a/skills/generate-style/SKILL.md
+++ b/skills/generate-style/SKILL.md
@@ -1,0 +1,18 @@
+---
+name: generate-style
+description: Generate the host repository STYLE.md by composing one or more selected templates from ./.styles/.
+---
+
+## When to use
+Use when `../STYLE.md` is missing or when the user wants to regenerate it after changing the repository art style mix.
+
+## Workflow
+1. If `../STYLE.md` is missing, ask the user which templates from `./.styles/` apply unless the user already named the desired style.
+2. Support multiple templates for mixed art-direction repositories.
+3. Generate `../STYLE.md` from the selected templates using concise read directives by default (for example `Read `./<mount>/.styles/ISOMETRIC_2_5D.md` instructions`) to avoid oversized files.
+4. Use inline mode only when the user explicitly asks for fully embedded template content.
+5. Treat `../STYLE.md` as the authoritative art style contract afterward.
+
+## Commands
+- `./commands/generate-style.sh "<STYLE1>" ["STYLE2" ...]`
+- `./commands/generate-style.sh --inline "<STYLE1>" ["STYLE2" ...]`

--- a/skills/maintain-art-style-contract/SKILL.md
+++ b/skills/maintain-art-style-contract/SKILL.md
@@ -1,0 +1,27 @@
+---
+name: maintain-art-style-contract
+description: Maintain, generate, or validate the host repository STYLE.md art contract from OpenCaw .styles templates. Use when visual work must preserve a project art direction, when a user asks to choose or change art styles, or when art roles need to verify that STYLE.md still references valid style templates.
+---
+
+## When to use
+Use when `../STYLE.md` is missing, stale, newly generated, or relevant to any visual, game-art, generated-image, UI-art, sprite, tileset, VFX, or art-handoff task.
+
+## Workflow
+1. Read `../STYLE.md` first when it exists; treat it as the authoritative project art contract.
+2. If `../STYLE.md` is missing or the user asks to change the style mix, inspect `./.styles/INDEX.md` and select the smallest useful template set.
+3. Generate or regenerate with `./commands/generate-style.sh "<STYLE1>" ["STYLE2" ...]`; use `--inline` only when the user explicitly asks for embedded template text.
+4. Validate the generated contract with `./commands/validate-style-contract.sh`.
+5. During art production, check outputs against both the active `STYLE.md` and the relevant role constraints.
+6. When a style conflict affects gameplay readability, asset metadata, engine loading, or UI contrast, call out the impacted owner role before proceeding.
+
+## Output
+- selected style template names
+- any missing or conflicting style instructions
+- whether `STYLE.md` was generated, left unchanged, or needs user confirmation
+- validation command output summary
+- role handoff notes when style decisions affect game design, engineering, QA, or documentation
+
+## Commands
+- `./commands/generate-style.sh "<STYLE1>" ["STYLE2" ...]`
+- `./commands/generate-style.sh --inline "<STYLE1>" ["STYLE2" ...]`
+- `./commands/validate-style-contract.sh [STYLE.md]`

--- a/skills/maintain-art-style-contract/agents/openai.yaml
+++ b/skills/maintain-art-style-contract/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Maintain Art Style Contract"
+  short_description: "Maintain and validate project STYLE.md art contracts."
+  default_prompt: "Use the active STYLE.md and OpenCaw .styles templates to align art work."

--- a/skills/prepare-game-art-handoff/SKILL.md
+++ b/skills/prepare-game-art-handoff/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: prepare-game-art-handoff
+description: Prepare game art assets for implementation handoff with style references, source/runtime file paths, atlas metadata, pivots, anchors, animation rows, collision assumptions, sorting layers, licensing, and validation checks. Use when art roles deliver assets to engineering, QA, game design, or documentation.
+---
+
+## When to use
+Use when sprites, tiles, props, VFX, UI icons, parallax layers, generated concepts, pre-rendered assets, or isometric art need to move from concept or production into an engine/runtime workflow.
+
+## Workflow
+1. Read `../STYLE.md` and any relevant `.styles` template before describing the handoff.
+2. Identify asset type, owner role, source file, runtime export, intended engine/runtime, and target scene or feature.
+3. Record metadata needed by implementation: dimensions, frame grid, atlas key, padding, pivot, anchor, origin, sorting layer, collision hints, animation names, loop rules, and compression expectations.
+4. For isometric assets, include projection, tile footprint, elevation unit, contact point, wall/roof/floor layer expectations, and occlusion strategy.
+5. Include validation evidence or required checks: style contract, readability, transparency, seams, animation playback, sorting, contrast, performance budget, and licensing.
+6. Name downstream responsibilities clearly so art, design, engineering, QA, and documentation do not infer hidden contracts.
+
+## Output
+- concise handoff brief
+- source and runtime asset paths
+- metadata table or manifest-ready fields
+- open questions and blocked assumptions
+- validation checklist
+- downstream role responsibilities
+
+## Commands
+- `./commands/print-game-art-handoff-template.sh [asset-type] [engine]`
+- `./commands/print-isometric-production-checklist.sh [asset-type]`
+- `./commands/inspect-animation-sheet-folder.sh [folder] [cell-size]`
+- `./commands/validate-style-contract.sh [STYLE.md]`

--- a/skills/prepare-game-art-handoff/agents/openai.yaml
+++ b/skills/prepare-game-art-handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Prepare Game Art Handoff"
+  short_description: "Prepare game art assets for engine implementation handoff."
+  default_prompt: "Create a production handoff for these game art assets with metadata, runtime assumptions, and validation checks."

--- a/skills/review-isometric-production/SKILL.md
+++ b/skills/review-isometric-production/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: review-isometric-production
+description: Review isometric and 2.5D game art for projection, tile metrics, anchors, elevation, depth sorting, occlusion, lighting, walkability, and gameplay readability. Use for isometric sprites, tiles, props, environments, VFX, maps, atlas handoffs, or style reviews.
+---
+
+## When to use
+Use whenever an art role creates, reviews, or hands off assets for an isometric-first game, especially when the asset interacts with tiles, elevation, collision, occlusion, characters, VFX, or UI markers.
+
+## Workflow
+1. Read `../STYLE.md`; if it references `ISOMETRIC_2_5D`, read `./.styles/ISOMETRIC_2_5D.md`.
+2. Confirm the projection, tile width/depth, elevation step, camera angle, character scale, and lighting direction before judging detail quality.
+3. Review anchors: character feet, prop bases, wall bases, roof slices, VFX origins, contact shadows, and atlas pivots.
+4. Review depth behavior: layer names, draw order, sortable slices, roof/wall/floor separation, foreground overlays, and tall-prop occlusion.
+5. Review gameplay readability: walkable ground, blockers, hazards, doors, stairs, cover, interactables, pickups, objectives, and UI markers.
+6. Require handoff metadata for any asset whose runtime behavior depends on pivots, collision, animation timing, sorting, or map placement.
+
+## Output
+- pass/fail or ready/needs-work summary
+- projection and scale assumptions
+- anchor, pivot, layer, and sorting findings
+- readability and collision concerns
+- required fixes before production handoff
+- downstream owner notes for art, design, engineering, QA, or documentation
+
+## Commands
+- `./commands/print-isometric-production-checklist.sh [asset-type]`
+- `./commands/print-game-art-handoff-template.sh [asset-type]`
+- `./commands/validate-style-contract.sh [STYLE.md]`

--- a/skills/review-isometric-production/agents/openai.yaml
+++ b/skills/review-isometric-production/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Isometric Production"
+  short_description: "Review isometric projection, anchors, sorting, and readability."
+  default_prompt: "Review this isometric game art for projection, anchors, depth sorting, and gameplay readability."


### PR DESCRIPTION
## Summary
- Add a formal `.styles` art style system and style-generation/validation commands.
- Add isometric-first game art roles, art production skills, and handoff/checklist commands.
- Add browser game architecture guidance for Three.js, Phaser, Tiled, Colyseus, and BabylonJS.
- Update existing art, frontend, fullstack, game design, QA, architecture, and writing roles to reference the new guidance and skills.

## Validation
- `bash ./commands/validate-opencaw.sh`
- `bash ./commands/validate-roles.sh`
- `bash ./commands/validate-skills.sh`
- `bash ./commands/validate-styles.sh`
- `bash ./commands/validate-commands.sh`
- `git diff --cached --check` before commit