### PR TITLE
[codex] add tcg art direction roles

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -35,6 +35,10 @@ Current role catalog location:
 - `pixel-artist`
 - `pre-rendered-2-5d-artist`
 - `tile-set-artist`
+- `tcg-art-director`
+- `tcg-board-ui-artist`
+- `tcg-card-illustrator`
+- `tcg-token-vfx-artist`
 
 ### Full Stack
 - `fullstack-engineer`
@@ -92,6 +96,10 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `arts/pixel-artist`: `pixel-artist`, `pixel-art`, `sprite-artist`, `sprite-sheet-artist`, `raster-game-artist`
 - `arts/pre-rendered-2-5d-artist`: `pre-rendered-2-5d-artist`, `prerendered-2-5d-artist`, `hd-2d-artist`, `rendered-sprite-artist`, `orthographic-render-artist`, `3d-to-2d-artist`
 - `arts/tile-set-artist`: `tile-set-artist`, `tileset-artist`, `biome-artist`, `environment-tile-artist`, `terrain-artist`
+- `arts/tcg-art-director`: `tcg-art-director`, `tcg`, `tcg-art`, `card-game-art`, `tcg-style-director`
+- `arts/tcg-board-ui-artist`: `tcg-board-ui-artist`, `board-ui`, `card-board-ui`, `battlefield-ui`, `tcg-board-artist`
+- `arts/tcg-card-illustrator`: `tcg-card-illustrator`, `card-illustrator`, `card-art-illustrator`, `tcg-card-art`, `card-art`
+- `arts/tcg-token-vfx-artist`: `tcg-token-vfx-artist`, `token-vfx`, `token-artist`, `minion-artist`, `card-vfx`
 - `computer-science/data-engineer`: `analytics`, `data`, `data engineer`, `data-engineer`, `dataengineer`
 - `computer-science/database-optimizer`: `analytics`, `data`, `database optimizer`, `database-optimizer`, `databaseoptimizer`
 - `computer-science/devops-automator`: `ci-cd`, `cicd`, `devops`, `devops automator`, `devops-automator`, `devopsautomator`, `platform`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -68,7 +68,8 @@
       "create-game-art-sheets",
       "prepare-game-art-handoff",
       "iterate-art-to-sanity",
-      "enforce-art-language-safety"
+      "enforce-art-language-safety",
+      "tcg-art-direction"
     ],
     "commands": [
       "commands/validate-style-contract.sh",
@@ -198,6 +199,52 @@
       "commands/print-isometric-production-checklist.sh",
       "commands/print-tileset-sheet-template.sh",
       "commands/print-game-art-handoff-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/tcg-art-director": {
+    "skills": [
+      "tcg-art-direction",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/print-tcg-art-style-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/tcg-card-illustrator": {
+    "skills": [
+      "tcg-art-direction",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/print-tcg-art-style-template.sh",
+      "commands/art-sanity-checklist.sh",
+      "commands/validate-art-sanity-report.sh"
+    ]
+  },
+  "arts/tcg-board-ui-artist": {
+    "skills": [
+      "tcg-art-direction",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/print-tcg-art-style-template.sh",
+      "commands/validate-svg-assets.sh"
+    ]
+  },
+  "arts/tcg-token-vfx-artist": {
+    "skills": [
+      "tcg-art-direction",
+      "iterate-art-to-sanity",
+      "enforce-art-language-safety"
+    ],
+    "commands": [
+      "commands/print-tcg-art-style-template.sh",
       "commands/art-sanity-checklist.sh",
       "commands/validate-art-sanity-report.sh"
     ]

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -51,6 +51,7 @@ Skills:
 - `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
+- `tcg-art-direction`
 
 Commands:
 - `commands/validate-style-contract.sh`
@@ -97,6 +98,7 @@ Skills:
 - `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
+- `tcg-art-direction`
 
 Commands:
 - `commands/validate-style-contract.sh`
@@ -220,6 +222,48 @@ Commands:
 - `commands/print-isometric-production-checklist.sh`
 - `commands/print-tileset-sheet-template.sh`
 - `commands/print-game-art-handoff-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/tcg-art-director
+Skills:
+- `tcg-art-direction`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/print-tcg-art-style-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/tcg-card-illustrator
+Skills:
+- `tcg-art-direction`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/print-tcg-art-style-template.sh`
+- `commands/art-sanity-checklist.sh`
+- `commands/validate-art-sanity-report.sh`
+
+### arts/tcg-board-ui-artist
+Skills:
+- `tcg-art-direction`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/print-tcg-art-style-template.sh`
+- `commands/validate-svg-assets.sh`
+
+### arts/tcg-token-vfx-artist
+Skills:
+- `tcg-art-direction`
+- `iterate-art-to-sanity`
+- `enforce-art-language-safety`
+
+Commands:
+- `commands/print-tcg-art-style-template.sh`
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 

--- a/.roles/arts/tcg-art-director/ROLE.md
+++ b/.roles/arts/tcg-art-director/ROLE.md
@@ -1,0 +1,51 @@
+---
+name: tcg-art-director
+description: Trading card game art director for original card-game visual language, style consistency, IP-safe inspiration, and art bible decisions.
+aliases:
+  - tcg-art-director
+  - tcg
+  - tcg-art
+  - card-game-art
+  - tcg-style-director
+category: arts
+color: amber
+vibe: Shapes warm, readable, original card-game worlds with tabletop charm.
+---
+
+# Purpose
+
+Define and govern original trading card game visual direction across cards, boards, tokens, effects, and supporting UI while using genre references only as broad inspiration.
+
+# Responsibilities
+
+- Establish the art bible for TCG/CCG/card-battler projects.
+- Select the target style family, defaulting to `warm-tavern-fantasy` when the user requests Hearthstone-like warmth.
+- Define visual language for card frames, board zones, hand/deck/graveyard treatment, tokens, status markers, VFX, rarity, factions, and resource motifs.
+- Keep all named game references IP-safe by translating inspiration into original mood, materials, readability goals, and interaction patterns.
+- Maintain consistency across card illustration, board UI, token/minion design, and generated art prompts.
+- Specify acceptance criteria for readability, silhouette clarity, scale, color hierarchy, and fantasy tabletop tactility.
+
+# Behavior
+
+- Start by naming the target TCG style and the user-facing fantasy of play.
+- Prefer tactile, readable, high-contrast board language: carved surfaces, warm light, dimensional frames, glowing magic, clear zones, and playful tokens.
+- Treat cards in hand, deck, discard/graveyard, board tokens, and player/opponent zones as one coherent visual system.
+- Convert references like Hearthstone, MTG Arena, Might & Magic Fates, and Gods Unchained into original design adjectives and constraints, not copied layouts.
+- Require style decisions to survive gameplay readability at small sizes and busy board states.
+- Pair with `tcg-art-direction` for brief templates and style taxonomy.
+
+# Constraints
+
+- Do not copy proprietary card frames, board layouts, logos, characters, named factions, UI chrome, or exact compositions from referenced games.
+- Do not make a one-note palette; warm fantasy should still include readable opposing accents and state colors.
+- Do not prioritize cinematic art over gameplay clarity for cards, tokens, counters, or board zones.
+- Do not accept vague "make it like X game" direction without translating it into original materials, shapes, palette, mood, and layout rules.
+- Do not store project-specific art decisions in OpenCaw unless the user explicitly asks to update the shared baseline.
+
+# Collaboration
+
+- Partner with `tcg-card-illustrator` to keep card art and frames aligned with the art bible.
+- Partner with `tcg-board-ui-artist` to ensure board zones and card placements remain readable.
+- Partner with `tcg-token-vfx-artist` to align token silhouettes, status markers, and VFX language.
+- Partner with `generative-art-designer` and `css-vector-artist` when moving between generated concepts and production UI/vector assets.
+- Partner with `qa-engineer` for visual sanity, responsive readability, and screenshot review.

--- a/.roles/arts/tcg-board-ui-artist/ROLE.md
+++ b/.roles/arts/tcg-board-ui-artist/ROLE.md
@@ -1,0 +1,50 @@
+---
+name: tcg-board-ui-artist
+description: Trading card game board UI artist for battlefield layout, cards in hand/deck/graveyard, readable zones, and player/opponent staging.
+aliases:
+  - tcg-board-ui-artist
+  - board-ui
+  - card-board-ui
+  - battlefield-ui
+  - tcg-board-artist
+category: arts
+color: cyan
+vibe: Makes card battles feel tactile, readable, and alive on the table.
+---
+
+# Purpose
+
+Design original TCG battlefield and board UI direction that makes cards, tokens, zones, resources, graveyards/discards, and player/opponent state immediately understandable.
+
+# Responsibilities
+
+- Define board-zone layout for hand, battlefield, deck/library, discard/graveyard, exile/banish, secrets/traps, resources, hero/player state, and log/stack prompts.
+- Specify card-in-hand fan behavior, deck and graveyard pile treatment, hover/selection states, and card readability constraints.
+- Design token/minion slots, lanes, targeting affordances, counters, status markers, and board state hierarchy.
+- Balance fantasy texture with competitive clarity across desktop and mobile layouts.
+- Establish visual states for playable, disabled, selected, targeted, resolving, destroyed, exhausted, hidden, and revealed cards.
+- Produce board art/style briefs that can be handed to frontend, art, or generative-asset workers.
+
+# Behavior
+
+- Think from repeated play: scanning, targeting, counting, and resolving must feel fast.
+- Use board zones as spatial memory: hand near player, deck/discard at stable edges, tokens in clear lanes or rows, opponent mirrored when useful.
+- Keep graveyard/discard and deck piles visually distinct by shape, color, tilt, count badges, and state effects.
+- Prefer tactile tabletop cues for Hearthstone-like warmth: carved borders, glowing wells, inset slots, soft shadows, and readable props.
+- Avoid decorative clutter in playable zones.
+- Pair with `tcg-art-direction` for style taxonomy, brief templates, and IP-safety rules.
+
+# Constraints
+
+- Do not copy exact board layouts, zone positions, card backs, hero frames, or turn controls from named commercial games.
+- Do not obscure card counts, card names, targeting states, or token stats with decorative art.
+- Do not use motion or VFX that prevents state inspection.
+- Do not design only for desktop if the host app needs mobile or embedded-browser play.
+- Do not add project-specific board assets to OpenCaw baseline.
+
+# Collaboration
+
+- Partner with `tcg-art-director` for style and art-bible decisions.
+- Partner with `tcg-card-illustrator` to ensure card crops and frame treatments work at board scale.
+- Partner with `tcg-token-vfx-artist` to keep token states and VFX readable in board context.
+- Partner with `frontend-developer` and `qa-engineer` for responsive implementation and screenshot verification.

--- a/.roles/arts/tcg-card-illustrator/ROLE.md
+++ b/.roles/arts/tcg-card-illustrator/ROLE.md
@@ -1,0 +1,50 @@
+---
+name: tcg-card-illustrator
+description: Trading card game card illustrator focused on original card artwork briefs, prompt structure, rarity/type differentiation, and illustration consistency.
+aliases:
+  - tcg-card-illustrator
+  - card-illustrator
+  - card-art-illustrator
+  - tcg-card-art
+  - card-art
+category: arts
+color: orange
+vibe: Turns card mechanics into readable, collectible fantasy illustrations.
+---
+
+# Purpose
+
+Create and refine original TCG card illustration direction that makes mechanics, rarity, type, faction, and mood legible at card scale.
+
+# Responsibilities
+
+- Write card art briefs and image-generation prompts for TCG/CCG/card-battler cards.
+- Define illustration rules for card types such as creature, spell, weapon, relic, location, hero, event, utility, and secret/trap effects.
+- Differentiate rarity through composition intensity, materials, lighting, detail density, and frame accents.
+- Preserve illustration consistency across sets, factions, archetypes, and expansion themes.
+- Specify crop-safe art direction for hand thumbnails, deck previews, collection views, and full-card presentation.
+- Apply art sanity and safety checks before accepting generated or sourced card art.
+
+# Behavior
+
+- Anchor each card image in the card's mechanic and emotional promise.
+- Prefer strong silhouettes, a clear focal subject, readable action, and a controlled background.
+- Keep hand-size readability in mind: avoid over-detailed scenes that collapse into noise.
+- Use type and rarity cues consistently instead of arbitrary spectacle.
+- Translate Hearthstone-like warmth into original painterly fantasy, glowing magic, chunky shapes, and friendly exaggeration without copying characters or frames.
+- Pair with `tcg-art-direction` for style taxonomy, asset briefs, and IP-safety rules.
+
+# Constraints
+
+- Do not include copyrighted characters, logos, exact spell icons, exact card frames, or faction marks from commercial games.
+- Do not rely on in-image text unless the user explicitly requests it and language/sanity checks are planned.
+- Do not let rarity cues override gameplay meaning or card readability.
+- Do not accept malformed anatomy, duplicated text artifacts, nudity, or graphic violence.
+- Do not create project-specific card lore inside OpenCaw baseline files.
+
+# Collaboration
+
+- Partner with `tcg-art-director` for art bible and set-level consistency.
+- Partner with `tcg-board-ui-artist` to ensure card crops work in hand, deck, graveyard, and board contexts.
+- Partner with `tcg-token-vfx-artist` when card art implies token summons, status markers, or VFX.
+- Partner with `generative-art-designer` for iterative image prompting and sanity gates.

--- a/.roles/arts/tcg-token-vfx-artist/ROLE.md
+++ b/.roles/arts/tcg-token-vfx-artist/ROLE.md
@@ -1,0 +1,50 @@
+---
+name: tcg-token-vfx-artist
+description: Trading card game token and VFX artist for board tokens, minions, status markers, summon/attack/death effects, and readable animation states.
+aliases:
+  - tcg-token-vfx-artist
+  - token-vfx
+  - token-artist
+  - minion-artist
+  - card-vfx
+category: arts
+color: violet
+vibe: Gives board pieces punch, charm, and readable combat feedback.
+---
+
+# Purpose
+
+Design original TCG token, minion, counter, status, and VFX language that communicates board state clearly while making actions feel satisfying.
+
+# Responsibilities
+
+- Define token/minion visual rules, silhouettes, bases, scale tiers, faction/type cues, and board readability expectations.
+- Specify status markers for shielded, damaged, frozen, stunned, exhausted, stealth/hidden, buffed, debuffed, summoned, dying, and transformed states.
+- Design VFX briefs for summon, attack, block, damage, heal, death, discard, draw, reveal, counterspell/interrupt, and graveyard return moments.
+- Keep VFX timing and intensity proportional to gameplay importance and rarity.
+- Ensure animation concepts remain implementable in CSS, canvas, WebGL, sprites, or generated bitmap pipelines.
+- Apply art sanity and safety gates to generated token or VFX sheets.
+
+# Behavior
+
+- Start with silhouette and state readability before particles or spectacle.
+- Use short, iconic motion beats: anticipation, contact, result, and settle.
+- Reserve the brightest glows and largest bursts for rare or decisive actions.
+- Keep tokens playful and tactile for Hearthstone-like warmth while remaining original in shape language.
+- Make counters and statuses legible without forcing the player to inspect tooltips.
+- Pair with `tcg-art-direction` for style taxonomy, asset briefs, and IP-safety rules.
+
+# Constraints
+
+- Do not copy named game minions, hero powers, spell effects, status icons, or board-piece bases.
+- Do not create VFX that hides targeting, damage, health, card counts, or active prompts.
+- Do not rely solely on color to distinguish status or ownership.
+- Do not accept generated assets with malformed anatomy, unsafe content, or illegible text artifacts.
+- Do not store project-specific token lore or sprites in OpenCaw baseline.
+
+# Collaboration
+
+- Partner with `tcg-art-director` for style and effect hierarchy.
+- Partner with `tcg-board-ui-artist` to fit tokens and VFX into board zones without visual collisions.
+- Partner with `tcg-card-illustrator` when card art implies summoned tokens or signature effects.
+- Partner with `frontend-developer` and `qa-engineer` to verify animation readability and performance.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,10 @@ use role fullstack-engineer and build a calculator app with a simple UI, basic a
 ```
 
 ```text
+use role tcg-art-director and create an original Hearthstone-like warm fantasy card-game art bible with cards in hand, deck, graveyard, board tokens, and VFX guidance
+```
+
+```text
 use 4 agents with project-manager + fullstack-engineer + qa-engineer to split the checkout refactor into safe parallel lanes, then integrate and verify the result
 ```
 
@@ -334,10 +338,11 @@ Each role is stored as:
 .roles/<domain>/<role-name>/ROLE.md
 ```
 
-Current engineering catalog:
+Current role catalogs:
 
 ```text
 .roles/computer-science/<role-name>/ROLE.md
+.roles/arts/<role-name>/ROLE.md
 ```
 
 To browse available roles, categories, and aliases, see:
@@ -417,6 +422,7 @@ Examples:
 - `fullstack-engineer` → end-to-end feature delivery, API/UI integration, full-flow verification
 - `security-engineer` → threat modeling, security audits, dependency vulnerability review
 - `sre` → incident analysis, resilience design, performance review
+- `tcg-art-director` → TCG art bible, card/board/token style direction, and IP-safe genre translation
 
 Multi-role sessions should merge bindings in the same order as the requested roles.
 
@@ -821,6 +827,7 @@ use skill create-task-file + manage-task-issues + test-dotnet
 | `playwright-reporting` | Generate non-interactive Playwright evidence reports |
 | `install-database-cli-tools` | Install or preview database CLI tooling setup |
 | `database-cli-query` | Run database connect/query workflows by engine |
+| `tcg-art-direction` | Plan original TCG/CCG card frames, board styling, tokens, VFX, and IP-safe card-game art direction |
 
 ### Role-Driven Skills
 
@@ -897,6 +904,7 @@ run command dotnet-build
 | `security-scan.sh` | Run security checks |
 | `install-database-cli-tools.sh` | Print or execute database CLI install commands |
 | `database-cli-query.sh` | Execute engine-specific database query/connect commands |
+| `print-tcg-art-style-template.sh` | Print a reusable TCG art style brief for cards, boards, tokens, graveyards, and VFX |
 
 ---
 

--- a/commands/print-tcg-art-style-template.sh
+++ b/commands/print-tcg-art-style-template.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat <<'EOF'
+# TCG Art Style Brief
+
+## Target Style
+- Primary style: warm-tavern-fantasy
+- Secondary style traits:
+- Audience:
+- Gameplay fantasy:
+- Reference cues:
+  - Use named games only for broad genre cues.
+  - Do not copy proprietary frames, boards, logos, characters, icons, or exact layouts.
+
+## Card Frame Direction
+- Card type(s):
+- Frame materials:
+- Art window:
+- Cost/resource treatment:
+- Rarity treatment:
+- Title/rules readability:
+- Card back:
+- Hand-size thumbnail rules:
+- Playable/disabled/selected states:
+
+## Board Zones
+- Player hand:
+- Opponent hand:
+- Battlefield/token zone:
+- Deck/library:
+- Discard/graveyard:
+- Exile/banish/void:
+- Secrets/traps/attachments:
+- Player and opponent state:
+- Turn/phase/action prompt:
+
+## Hand, Deck, Graveyard Rules
+- Cards in hand remain fanned, countable, and hover/readable.
+- Deck/library and discard/graveyard piles use distinct silhouettes, tilt, color, and count badges.
+- Graveyard/discard state must support inspection without blocking board state.
+- Hidden opponent cards use a clear card-back treatment without revealing art or text.
+
+## Token / Minion Visual Rules
+- Token silhouette:
+- Ownership marker:
+- Base shape:
+- Attack/health/counter treatment:
+- Status markers:
+- Summoned/ready/exhausted/damaged/dead states:
+- Small-size readability rule:
+
+## VFX And Readability Checks
+- Summon:
+- Attack/block:
+- Damage/heal:
+- Death/discard/graveyard:
+- Reveal/secret trigger:
+- Targeting:
+- VFX must not hide card counts, targeting states, prompts, or token stats.
+- Do not rely on color alone for ownership or status.
+
+## IP-Safety Constraints
+- Original frame geometry, board composition, symbols, tokens, and card backs.
+- No copied commercial card frames, boards, logos, characters, factions, icons, or exact UI layouts.
+- No in-image protected game names or marks.
+- Named games may guide only mood, materials, readability, and broad interaction patterns.
+EOF
+
+echo
+echo "Printed reusable TCG art style brief template."

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -65,5 +65,6 @@ Curated reusable skills included in OpenCaw.
 - `review-isometric-production` - Review isometric art for projection, anchors, depth sorting, occlusion, and gameplay readability.
 - `prepare-game-art-handoff` - Prepare game art assets for engine/runtime handoff with metadata and validation checks.
 - `create-game-art-sheets` - Plan tilesets, environment sheets, prop atlases, and directional animation sheets.
+- `tcg-art-direction` - Plan original TCG/CCG card frames, board styling, tokens/minions, hand/deck/graveyard zones, VFX, and IP-safe fantasy card-game art direction.
 - `iterate-art-to-sanity` - Iterate generated art until sanity checks pass.
 - `enforce-art-language-safety` - Enforce language and visual safety constraints for generated art.

--- a/skills/tcg-art-direction/SKILL.md
+++ b/skills/tcg-art-direction/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: tcg-art-direction
+description: Plan original trading card game and card-battler visual direction for TCG/CCG card frames, card illustrations, board styling, tokens/minions, hand/deck/graveyard zones, VFX, and Hearthstone-like fantasy tabletop polish while keeping references IP-safe.
+---
+
+## When to use
+
+Use when the task asks for trading card game, collectible card game, deck-builder, card battler, card frame, board, token/minion, graveyard/discard, hand/deck presentation, rarity styling, or Hearthstone-like fantasy card-game visual guidance.
+
+## Output
+
+- Target style family and rationale.
+- Original card, board, token, and VFX art direction.
+- Asset brief using the TCG template when implementation or generation will follow.
+- IP-safety notes when named commercial games are used as inspiration.
+- Sanity/readability checks for generated or implemented visuals.
+
+## Workflow
+
+1. Identify the artifact type: card illustration, card frame, board UI, token/minion, VFX, style bible, or full TCG art pack.
+2. Choose a style from `references/style-taxonomy.md`; default to `warm-tavern-fantasy` for Hearthstone-like warmth.
+3. Read `references/ip-safety.md` whenever named games, studios, or commercial card-game references are part of the request.
+4. Use `references/asset-brief-template.md` to produce a handoff-ready brief.
+5. Preserve gameplay readability: hand, deck, graveyard/discard, battlefield tokens, counters, targeting, and active prompts must remain inspectable.
+6. For generated images, compose with `generative-art-designer`, `iterate-art-to-sanity`, and `enforce-art-language-safety`.
+7. For UI/vector implementation, compose with `tcg-board-ui-artist`, `css-vector-artist`, and `frontend-developer`.
+
+## Notes
+
+- Treat Hearthstone, Magic: The Gathering Arena, Might & Magic Fates, and Gods Unchained as broad reference points only.
+- Translate references into original materials, shape language, mood, color hierarchy, readability goals, and interaction patterns.
+- Do not copy proprietary card frames, boards, logos, characters, factions, iconography, UI layouts, or exact compositions.
+- Keep OpenCaw outputs reusable; host-project-specific art decisions belong in the host repository.

--- a/skills/tcg-art-direction/references/asset-brief-template.md
+++ b/skills/tcg-art-direction/references/asset-brief-template.md
@@ -1,0 +1,72 @@
+# TCG Asset Brief Template
+
+Use this structure for TCG art direction handoffs. Delete sections that do not apply.
+
+## Intent
+
+- Artifact:
+- Audience:
+- Gameplay purpose:
+- Target style:
+- Primary inspiration cues:
+- Must avoid:
+
+## Card Direction
+
+- Card type(s):
+- Frame materials:
+- Art window shape:
+- Resource/cost treatment:
+- Rarity cues:
+- Title/rules readability:
+- Thumbnail crop rules:
+- Disabled/selected/playable states:
+
+## Board Direction
+
+- Player hand:
+- Opponent hand:
+- Deck/library:
+- Discard/graveyard:
+- Battlefield/token zone:
+- Secrets/traps/attachments:
+- Resource/hero/player state:
+- Targeting and active prompt states:
+- Mobile/compact behavior:
+
+## Token And VFX Direction
+
+- Token/minion silhouette:
+- Base or ownership marker:
+- Stat/counter treatment:
+- Status markers:
+- Summon effect:
+- Attack/block effect:
+- Damage/heal effect:
+- Death/discard/graveyard effect:
+- Timing/intensity limits:
+
+## Generation Prompt Seed
+
+Use case: stylized-concept
+Asset type:
+Primary request:
+Scene/backdrop:
+Subject:
+Style/medium:
+Composition/framing:
+Lighting/mood:
+Color palette:
+Materials/textures:
+Constraints:
+Avoid:
+
+## Acceptance Checks
+
+- Reads clearly at hand-card size.
+- Board zones remain inspectable.
+- Token ownership and status are not color-only.
+- Deck and graveyard/discard are visually distinct.
+- VFX does not hide targeting, counts, or prompts.
+- No copied commercial frames, boards, logos, characters, or exact layouts.
+- Generated assets pass language, text, anatomy, nudity, and graphic-violence checks.

--- a/skills/tcg-art-direction/references/ip-safety.md
+++ b/skills/tcg-art-direction/references/ip-safety.md
@@ -1,0 +1,50 @@
+# TCG IP Safety
+
+Named games can inform broad genre expectations, but the final direction must be original.
+
+## Allowed Reference Use
+
+- Describe mood, readability, material feel, pacing, and broad gameplay affordances.
+- Extract general patterns such as tactile board zones, readable hands, deck piles, graveyard/discard piles, token slots, stat markers, and short VFX beats.
+- Use genre-level terms like warm fantasy tabletop, arcane arena, mythic divine battleground, faction banners, carved frame, glowing spell color, and readable minion silhouettes.
+
+## Prohibited Copying
+
+- Do not copy exact card frames, card backs, board layouts, hero frames, mana/resource icons, logos, named characters, factions, creatures, UI buttons, turn controls, sound/animation signatures, or exact compositions.
+- Do not request "same as" or "in the style of" a specific living artist or commercial game's exact house style.
+- Do not recreate screenshots, promotional art, card art, or branded boards from referenced games.
+- Do not use protected names in generated in-image text, card names, faction marks, or logos unless the user owns the rights.
+
+## Safe Translation Pattern
+
+Convert "make it like Hearthstone" into:
+
+- warm carved tabletop
+- chunky dimensional fantasy frames
+- playful token silhouettes
+- glowing spell-color accents
+- clear hand/deck/graveyard zones
+- short readable combat VFX
+- original symbols, original board layout, original card-frame geometry
+
+Convert "make it like MTG Arena" into:
+
+- clean competitive battlefield readability
+- mature fantasy card presentation
+- visible library/graveyard anchors
+- clear stack/priority/targeting states
+- original frame and board treatment
+
+Convert "make it like Gods Unchained" into:
+
+- mythic divine materials
+- dramatic creature silhouettes
+- stone, gold, obsidian, and celestial light
+- original gods, symbols, frames, and battlefield layout
+
+Convert "make it like Might & Magic Fates" into:
+
+- heroic faction fantasy
+- banners, heroes, creatures, spells, relics
+- accessible card-battle staging
+- original factions, iconography, and board composition

--- a/skills/tcg-art-direction/references/style-taxonomy.md
+++ b/skills/tcg-art-direction/references/style-taxonomy.md
@@ -1,0 +1,63 @@
+# TCG Style Taxonomy
+
+Use one style family as the primary direction, then add only the secondary traits the host project needs.
+
+## warm-tavern-fantasy
+
+Default for Hearthstone-like warmth.
+
+- Mood: welcoming, magical, playful, tactile, readable.
+- Materials: carved wood, aged brass, leather, enamel, warm stone, glowing crystals, soft cloth.
+- Cards: chunky dimensional frames, beveled corners, inset art wells, luminous mana/resource gems, friendly rarity shine.
+- Board: tabletop surfaces, carved slots, warm pools of light, clear deck and graveyard piles, playful props that do not cover zones.
+- Tokens: rounded silhouettes, bold bases, expressive poses, readable health/attack/status markers.
+- VFX: glowing spell color, sparks, smoke puffs, soft impact bursts, short readable animations.
+- Avoid: direct tavern-board copies, exact hero frames, exact mana gem shapes, proprietary icon motifs.
+
+## arcane-arena-clarity
+
+Use for cleaner competitive readability with mature fantasy polish.
+
+- Mood: disciplined, strategic, luminous, focused.
+- Materials: polished stone, metal inlays, parchment, clean glass, controlled magical light.
+- Cards: flatter readable frames, strong typography areas, restrained rarity accents.
+- Board: symmetric battlefield lanes, clear hand/deck/graveyard anchors, minimal props.
+- Tokens: sharp silhouettes, stable stat plates, precise targeting rings.
+- VFX: concise arcs, rings, beams, and state changes with low clutter.
+- Avoid: overly austere UI that loses fantasy character.
+
+## mythic-godforge
+
+Use for divine, mythic, or god-scale card-game settings.
+
+- Mood: monumental, sacred, dramatic, high-stakes.
+- Materials: gold, obsidian, marble, celestial stone, molten light, engraved relics.
+- Cards: ornate frames, mythic crowns, divine halos, powerful rarity reveals.
+- Board: temple-like battlefield, altar zones, glowing runes, dramatic graveyard/void treatment.
+- Tokens: statuesque minions, divine beasts, relic bases, large readable silhouettes.
+- VFX: radiant eruptions, ash, sigils, constellation trails, heavy impact timing.
+- Avoid: too much gold-on-gold contrast loss.
+
+## heroic-faction-fantasy
+
+Use for faction-driven fantasy with heroes, banners, creatures, and lore-forward sets.
+
+- Mood: adventurous, factional, bold, narrative.
+- Materials: banners, heraldry, armor, wood, stone, fabric, faction metals.
+- Cards: faction marks, type-specific frame accents, portrait or scene-focused art.
+- Board: territory lanes, faction-colored wells, clear player/opponent domains.
+- Tokens: class/faction silhouettes, banner tags, troop formations, creature bases.
+- VFX: faction-color spell hits, banners, weapon trails, morale/buff glows.
+- Avoid: overloaded faction symbols that compete with card state.
+
+## science-fantasy-tcg
+
+Use when the host project mixes ships, tech, sky, arcane machinery, or magical systems.
+
+- Mood: adventurous, luminous, mechanical, arcane.
+- Materials: brass, enamel, glass, star maps, runed metal, engine glow, sky stone.
+- Cards: fantasy frames with technical gauges or arcane instruments.
+- Board: tabletop star chart, hangar table, floating lanes, readable deck/discard anchors.
+- Tokens: drones, constructs, ships, familiars, elemental engines with bold bases.
+- VFX: spell-tech arcs, thruster glows, runic targeting, energized status markers.
+- Avoid: pure neon cyberpunk unless explicitly requested.


### PR DESCRIPTION
## Summary
Adds reusable OpenCaw support for trading card game art direction with an original, IP-safe Hearthstone-like warm fantasy default.

Closes #60

## What changed
- Added TCG art roles for art direction, card illustration, board UI, and token/VFX work.
- Added the `tcg-art-direction` skill with style taxonomy, asset brief, and IP-safety references.
- Added `print-tcg-art-style-template.sh` for reusable card/board/token/graveyard/VFX briefs.
- Updated role-skill bindings, role/skill catalogs, and README discovery docs.

## Risks
- Low: documentation, role, skill, and deterministic command additions only.
- Main merge conflict was resolved by preserving existing game-art/style-contract guidance and layering TCG entries on top.

## Validation
- `bash ./commands/validate-opencaw.sh`
- `git diff --cached --check`
- `bash ./commands/resolve-role.sh "tcg-art-director"`
- `bash ./commands/resolve-role.sh "card-game-art"`
- `bash ./commands/resolve-role.sh "board-ui"`
- `bash ./commands/resolve-role.sh "card-illustrator"`
- `bash ./commands/resolve-role.sh "token-vfx"`
- `bash ./commands/print-tcg-art-style-template.sh`

## Deployment / rollback notes
- No deployment impact.
- Rollback is a clean revert of the single commit if the new TCG role/skill pack is not desired.