### PR TITLE
rename tcg art roles

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -23,6 +23,9 @@ Current role catalog location:
 - `mobile-app-builder`
 
 ### Arts & Visual Design
+- `art-director`
+- `board-ui-artist`
+- `card-illustrator`
 - `css-vector-artist`
 - `cutout-rig-animator`
 - `flat-minimalist-game-artist`
@@ -35,10 +38,7 @@ Current role catalog location:
 - `pixel-artist`
 - `pre-rendered-2-5d-artist`
 - `tile-set-artist`
-- `tcg-art-director`
-- `tcg-board-ui-artist`
-- `tcg-card-illustrator`
-- `tcg-token-vfx-artist`
+- `token-vfx-artist`
 
 ### Full Stack
 - `fullstack-engineer`
@@ -84,6 +84,9 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `computer-science/backend-architect`: `api`, `api-architect`, `architect`, `backend`, `backend architect`, `backend-architect`, `backendarchitect`
 - `computer-science/code-migrator`: `code migrator`, `code-migrator`, `codemigrator`, `migration-engineer`, `modernization-engineer`
 - `computer-science/code-reviewer`: `code reviewer`, `code-reviewer`, `codereviewer`
+- `arts/art-director`: `art-director`, `card-game-art`, `style-director`, `card-game-style-director`
+- `arts/board-ui-artist`: `board-ui-artist`, `board-ui`, `card-board-ui`, `battlefield-ui`, `board-artist`
+- `arts/card-illustrator`: `card-illustrator`, `card-art-illustrator`, `card-art`
 - `arts/css-vector-artist`: `css-vector-artist`, `css-vector`, `interface-vector-artist`, `logo-vector-artist`, `vector-ui-artist`
 - `arts/cutout-rig-animator`: `cutout-rig-animator`, `cutout-animator`, `skeletal-2d-animator`, `puppet-animation-artist`, `bone-rig-artist`, `sprite-rig-animator`
 - `arts/flat-minimalist-game-artist`: `flat-minimalist-game-artist`, `flat-game-artist`, `minimalist-game-artist`, `geometric-game-artist`, `monochrome-game-artist`, `simple-shape-artist`
@@ -96,10 +99,7 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `arts/pixel-artist`: `pixel-artist`, `pixel-art`, `sprite-artist`, `sprite-sheet-artist`, `raster-game-artist`
 - `arts/pre-rendered-2-5d-artist`: `pre-rendered-2-5d-artist`, `prerendered-2-5d-artist`, `hd-2d-artist`, `rendered-sprite-artist`, `orthographic-render-artist`, `3d-to-2d-artist`
 - `arts/tile-set-artist`: `tile-set-artist`, `tileset-artist`, `biome-artist`, `environment-tile-artist`, `terrain-artist`
-- `arts/tcg-art-director`: `tcg-art-director`, `tcg`, `tcg-art`, `card-game-art`, `tcg-style-director`
-- `arts/tcg-board-ui-artist`: `tcg-board-ui-artist`, `board-ui`, `card-board-ui`, `battlefield-ui`, `tcg-board-artist`
-- `arts/tcg-card-illustrator`: `tcg-card-illustrator`, `card-illustrator`, `card-art-illustrator`, `tcg-card-art`, `card-art`
-- `arts/tcg-token-vfx-artist`: `tcg-token-vfx-artist`, `token-vfx`, `token-artist`, `minion-artist`, `card-vfx`
+- `arts/token-vfx-artist`: `token-vfx-artist`, `token-vfx`, `token-artist`, `minion-artist`, `card-vfx`
 - `computer-science/data-engineer`: `analytics`, `data`, `data engineer`, `data-engineer`, `dataengineer`
 - `computer-science/database-optimizer`: `analytics`, `data`, `database optimizer`, `database-optimizer`, `databaseoptimizer`
 - `computer-science/devops-automator`: `ci-cd`, `cicd`, `devops`, `devops automator`, `devops-automator`, `devopsautomator`, `platform`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -203,7 +203,7 @@
       "commands/validate-art-sanity-report.sh"
     ]
   },
-  "arts/tcg-art-director": {
+  "arts/art-director": {
     "skills": [
       "tcg-art-direction",
       "iterate-art-to-sanity",
@@ -215,7 +215,7 @@
       "commands/validate-art-sanity-report.sh"
     ]
   },
-  "arts/tcg-card-illustrator": {
+  "arts/card-illustrator": {
     "skills": [
       "tcg-art-direction",
       "iterate-art-to-sanity",
@@ -227,7 +227,7 @@
       "commands/validate-art-sanity-report.sh"
     ]
   },
-  "arts/tcg-board-ui-artist": {
+  "arts/board-ui-artist": {
     "skills": [
       "tcg-art-direction",
       "enforce-art-language-safety"
@@ -237,7 +237,7 @@
       "commands/validate-svg-assets.sh"
     ]
   },
-  "arts/tcg-token-vfx-artist": {
+  "arts/token-vfx-artist": {
     "skills": [
       "tcg-art-direction",
       "iterate-art-to-sanity",

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -225,7 +225,7 @@ Commands:
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
-### arts/tcg-art-director
+### arts/art-director
 Skills:
 - `tcg-art-direction`
 - `iterate-art-to-sanity`
@@ -236,7 +236,7 @@ Commands:
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
-### arts/tcg-card-illustrator
+### arts/card-illustrator
 Skills:
 - `tcg-art-direction`
 - `iterate-art-to-sanity`
@@ -247,7 +247,7 @@ Commands:
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 
-### arts/tcg-board-ui-artist
+### arts/board-ui-artist
 Skills:
 - `tcg-art-direction`
 - `enforce-art-language-safety`
@@ -256,7 +256,7 @@ Commands:
 - `commands/print-tcg-art-style-template.sh`
 - `commands/validate-svg-assets.sh`
 
-### arts/tcg-token-vfx-artist
+### arts/token-vfx-artist
 Skills:
 - `tcg-art-direction`
 - `iterate-art-to-sanity`

--- a/.roles/arts/art-director/ROLE.md
+++ b/.roles/arts/art-director/ROLE.md
@@ -1,12 +1,11 @@
 ---
-name: tcg-art-director
+name: art-director
 description: Trading card game art director for original card-game visual language, style consistency, IP-safe inspiration, and art bible decisions.
 aliases:
-  - tcg-art-director
-  - tcg
-  - tcg-art
+  - art-director
   - card-game-art
-  - tcg-style-director
+  - style-director
+  - card-game-style-director
 category: arts
 color: amber
 vibe: Shapes warm, readable, original card-game worlds with tabletop charm.
@@ -44,8 +43,8 @@ Define and govern original trading card game visual direction across cards, boar
 
 # Collaboration
 
-- Partner with `tcg-card-illustrator` to keep card art and frames aligned with the art bible.
-- Partner with `tcg-board-ui-artist` to ensure board zones and card placements remain readable.
-- Partner with `tcg-token-vfx-artist` to align token silhouettes, status markers, and VFX language.
+- Partner with `card-illustrator` to keep card art and frames aligned with the art bible.
+- Partner with `board-ui-artist` to ensure board zones and card placements remain readable.
+- Partner with `token-vfx-artist` to align token silhouettes, status markers, and VFX language.
 - Partner with `generative-art-designer` and `css-vector-artist` when moving between generated concepts and production UI/vector assets.
 - Partner with `qa-engineer` for visual sanity, responsive readability, and screenshot review.

--- a/.roles/arts/board-ui-artist/ROLE.md
+++ b/.roles/arts/board-ui-artist/ROLE.md
@@ -1,12 +1,12 @@
 ---
-name: tcg-board-ui-artist
+name: board-ui-artist
 description: Trading card game board UI artist for battlefield layout, cards in hand/deck/graveyard, readable zones, and player/opponent staging.
 aliases:
-  - tcg-board-ui-artist
+  - board-ui-artist
   - board-ui
   - card-board-ui
   - battlefield-ui
-  - tcg-board-artist
+  - board-artist
 category: arts
 color: cyan
 vibe: Makes card battles feel tactile, readable, and alive on the table.
@@ -44,7 +44,7 @@ Design original TCG battlefield and board UI direction that makes cards, tokens,
 
 # Collaboration
 
-- Partner with `tcg-art-director` for style and art-bible decisions.
-- Partner with `tcg-card-illustrator` to ensure card crops and frame treatments work at board scale.
-- Partner with `tcg-token-vfx-artist` to keep token states and VFX readable in board context.
+- Partner with `art-director` for style and art-bible decisions.
+- Partner with `card-illustrator` to ensure card crops and frame treatments work at board scale.
+- Partner with `token-vfx-artist` to keep token states and VFX readable in board context.
 - Partner with `frontend-developer` and `qa-engineer` for responsive implementation and screenshot verification.

--- a/.roles/arts/card-illustrator/ROLE.md
+++ b/.roles/arts/card-illustrator/ROLE.md
@@ -1,11 +1,9 @@
 ---
-name: tcg-card-illustrator
+name: card-illustrator
 description: Trading card game card illustrator focused on original card artwork briefs, prompt structure, rarity/type differentiation, and illustration consistency.
 aliases:
-  - tcg-card-illustrator
   - card-illustrator
   - card-art-illustrator
-  - tcg-card-art
   - card-art
 category: arts
 color: orange
@@ -44,7 +42,7 @@ Create and refine original TCG card illustration direction that makes mechanics,
 
 # Collaboration
 
-- Partner with `tcg-art-director` for art bible and set-level consistency.
-- Partner with `tcg-board-ui-artist` to ensure card crops work in hand, deck, graveyard, and board contexts.
-- Partner with `tcg-token-vfx-artist` when card art implies token summons, status markers, or VFX.
+- Partner with `art-director` for art bible and set-level consistency.
+- Partner with `board-ui-artist` to ensure card crops work in hand, deck, graveyard, and board contexts.
+- Partner with `token-vfx-artist` when card art implies token summons, status markers, or VFX.
 - Partner with `generative-art-designer` for iterative image prompting and sanity gates.

--- a/.roles/arts/token-vfx-artist/ROLE.md
+++ b/.roles/arts/token-vfx-artist/ROLE.md
@@ -1,8 +1,8 @@
 ---
-name: tcg-token-vfx-artist
+name: token-vfx-artist
 description: Trading card game token and VFX artist for board tokens, minions, status markers, summon/attack/death effects, and readable animation states.
 aliases:
-  - tcg-token-vfx-artist
+  - token-vfx-artist
   - token-vfx
   - token-artist
   - minion-artist
@@ -44,7 +44,7 @@ Design original TCG token, minion, counter, status, and VFX language that commun
 
 # Collaboration
 
-- Partner with `tcg-art-director` for style and effect hierarchy.
-- Partner with `tcg-board-ui-artist` to fit tokens and VFX into board zones without visual collisions.
-- Partner with `tcg-card-illustrator` when card art implies summoned tokens or signature effects.
+- Partner with `art-director` for style and effect hierarchy.
+- Partner with `board-ui-artist` to fit tokens and VFX into board zones without visual collisions.
+- Partner with `card-illustrator` when card art implies summoned tokens or signature effects.
 - Partner with `frontend-developer` and `qa-engineer` to verify animation readability and performance.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ use role fullstack-engineer and build a calculator app with a simple UI, basic a
 ```
 
 ```text
-use role tcg-art-director and create an original Hearthstone-like warm fantasy card-game art bible with cards in hand, deck, graveyard, board tokens, and VFX guidance
+use role art-director and create an original Hearthstone-like warm fantasy card-game art bible with cards in hand, deck, graveyard, board tokens, and VFX guidance
 ```
 
 ```text
@@ -422,7 +422,7 @@ Examples:
 - `fullstack-engineer` → end-to-end feature delivery, API/UI integration, full-flow verification
 - `security-engineer` → threat modeling, security audits, dependency vulnerability review
 - `sre` → incident analysis, resilience design, performance review
-- `tcg-art-director` → TCG art bible, card/board/token style direction, and IP-safe genre translation
+- `art-director` → TCG art bible, card/board/token style direction, and IP-safe genre translation
 
 Multi-role sessions should merge bindings in the same order as the requested roles.
 

--- a/skills/tcg-art-direction/SKILL.md
+++ b/skills/tcg-art-direction/SKILL.md
@@ -23,7 +23,7 @@ Use when the task asks for trading card game, collectible card game, deck-builde
 4. Use `references/asset-brief-template.md` to produce a handoff-ready brief.
 5. Preserve gameplay readability: hand, deck, graveyard/discard, battlefield tokens, counters, targeting, and active prompts must remain inspectable.
 6. For generated images, compose with `generative-art-designer`, `iterate-art-to-sanity`, and `enforce-art-language-safety`.
-7. For UI/vector implementation, compose with `tcg-board-ui-artist`, `css-vector-artist`, and `frontend-developer`.
+7. For UI/vector implementation, compose with `board-ui-artist`, `css-vector-artist`, and `frontend-developer`.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Renames the TCG-specific arts role IDs to generic role names so they can be referenced by role rather than by a TCG-specific purpose prefix.

## What changed

- Renamed role folders and front matter:
  - `tcg-art-director` -> `art-director`
  - `tcg-board-ui-artist` -> `board-ui-artist`
  - `tcg-card-illustrator` -> `card-illustrator`
  - `tcg-token-vfx-artist` -> `token-vfx-artist`
- Updated role aliases, collaboration references, `INDEX.md`, `ROLE_SKILL_MAP.md`, and `ROLE_SKILL_MAP.json`.
- Updated README examples and `tcg-art-direction` composition guidance to use the generic role IDs.

## Risks

- Existing prompts or automation that still use the old `tcg-*` role IDs will need to switch to the new generic IDs.
- TCG-specific skills and commands are intentionally unchanged because this PR only renames role identities.

## Validation

- `bash ./commands/validate-opencaw.sh` passed.
- `bash ./commands/resolve-role.sh art-director` resolved `arts/art-director` by exact name.
- `bash ./commands/resolve-role.sh board-ui-artist` resolved `arts/board-ui-artist` by exact name.
- `bash ./commands/resolve-role.sh card-illustrator` resolved `arts/card-illustrator` by exact name.
- `bash ./commands/resolve-role.sh token-vfx-artist` resolved `arts/token-vfx-artist` by exact name.

## Deployment / rollback notes

- No deployment impact; this is a baseline configuration/documentation change.
- Rollback is a clean revert of the commit if old role IDs need to be restored.