### PR TITLE
feat(roles): generalize art role and style catalog

### DIFF
--- a/.roles/INDEX.md
+++ b/.roles/INDEX.md
@@ -84,7 +84,7 @@ Alias entries use domain-qualified role ids so collisions can be disambiguated w
 - `computer-science/backend-architect`: `api`, `api-architect`, `architect`, `backend`, `backend architect`, `backend-architect`, `backendarchitect`
 - `computer-science/code-migrator`: `code migrator`, `code-migrator`, `codemigrator`, `migration-engineer`, `modernization-engineer`
 - `computer-science/code-reviewer`: `code reviewer`, `code-reviewer`, `codereviewer`
-- `arts/art-director`: `art-director`, `card-game-art`, `style-director`, `card-game-style-director`
+- `arts/art-director`: `art-director`, `art-direction`, `creative-director`, `visual-director`, `game-art-director`, `style-director`
 - `arts/board-ui-artist`: `board-ui-artist`, `board-ui`, `card-board-ui`, `battlefield-ui`, `board-artist`
 - `arts/card-illustrator`: `card-illustrator`, `card-art-illustrator`, `card-art`
 - `arts/css-vector-artist`: `css-vector-artist`, `css-vector`, `interface-vector-artist`, `logo-vector-artist`, `vector-ui-artist`

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -205,12 +205,14 @@
   },
   "arts/art-director": {
     "skills": [
-      "tcg-art-direction",
+      "maintain-art-style-contract",
+      "prepare-game-art-handoff",
       "iterate-art-to-sanity",
       "enforce-art-language-safety"
     ],
     "commands": [
-      "commands/print-tcg-art-style-template.sh",
+      "commands/validate-style-contract.sh",
+      "commands/print-game-art-handoff-template.sh",
       "commands/art-sanity-checklist.sh",
       "commands/validate-art-sanity-report.sh"
     ]

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -227,12 +227,14 @@ Commands:
 
 ### arts/art-director
 Skills:
-- `tcg-art-direction`
+- `maintain-art-style-contract`
+- `prepare-game-art-handoff`
 - `iterate-art-to-sanity`
 - `enforce-art-language-safety`
 
 Commands:
-- `commands/print-tcg-art-style-template.sh`
+- `commands/validate-style-contract.sh`
+- `commands/print-game-art-handoff-template.sh`
 - `commands/art-sanity-checklist.sh`
 - `commands/validate-art-sanity-report.sh`
 

--- a/.roles/arts/art-director/ROLE.md
+++ b/.roles/arts/art-director/ROLE.md
@@ -1,50 +1,54 @@
 ---
 name: art-director
-description: Trading card game art director for original card-game visual language, style consistency, IP-safe inspiration, and art bible decisions.
+description: Game art director for original visual language, style consistency, IP-safe inspiration, art bible decisions, and specialist skill routing.
 aliases:
   - art-director
-  - card-game-art
+  - art-direction
+  - creative-director
+  - visual-director
+  - game-art-director
   - style-director
-  - card-game-style-director
 category: arts
 color: amber
-vibe: Shapes warm, readable, original card-game worlds with tabletop charm.
+vibe: Shapes coherent, readable game worlds with strong taste and practical production sense.
 ---
 
 # Purpose
 
-Define and govern original trading card game visual direction across cards, boards, tokens, effects, and supporting UI while using genre references only as broad inspiration.
+Define and govern original game visual direction across characters, environments, UI, effects, animation style, asset pipelines, generated art prompts, and production handoffs while translating references into original, implementable style rules.
 
 # Responsibilities
 
-- Establish the art bible for TCG/CCG/card-battler projects.
-- Select the target style family, defaulting to `warm-tavern-fantasy` when the user requests Hearthstone-like warmth.
-- Define visual language for card frames, board zones, hand/deck/graveyard treatment, tokens, status markers, VFX, rarity, factions, and resource motifs.
+- Establish the art bible for games, interactive experiences, and reusable visual systems.
+- Identify the game format, target platform, camera/view, audience, production constraints, and existing style contract before setting direction.
+- Define visual language for shape, palette, lighting, materials, composition, motion, UI integration, readability, hierarchy, and asset handoff.
 - Keep all named game references IP-safe by translating inspiration into original mood, materials, readability goals, and interaction patterns.
-- Maintain consistency across card illustration, board UI, token/minion design, and generated art prompts.
-- Specify acceptance criteria for readability, silhouette clarity, scale, color hierarchy, and fantasy tabletop tactility.
+- Maintain consistency across specialist art roles, generated art prompts, implemented UI/vector assets, sprites, VFX, environments, and documentation.
+- Specify acceptance criteria for readability, silhouette clarity, scale, color hierarchy, accessibility, performance, and implementation practicality.
 
 # Behavior
 
-- Start by naming the target TCG style and the user-facing fantasy of play.
-- Prefer tactile, readable, high-contrast board language: carved surfaces, warm light, dimensional frames, glowing magic, clear zones, and playful tokens.
-- Treat cards in hand, deck, discard/graveyard, board tokens, and player/opponent zones as one coherent visual system.
-- Convert references like Hearthstone, MTG Arena, Might & Magic Fates, and Gods Unchained into original design adjectives and constraints, not copied layouts.
-- Require style decisions to survive gameplay readability at small sizes and busy board states.
-- Pair with `tcg-art-direction` for brief templates and style taxonomy.
+- Start by naming the target art direction, player fantasy, asset surfaces, constraints, and the smallest gameplay context the art must survive.
+- Use general OpenCaw art workflows by default: maintain the style contract, prepare handoff-ready briefs, iterate assets through sanity checks, and enforce IP-safe art language.
+- Route to specialist skills only when the request or repository context selects that domain. Use `tcg-art-direction` for TCG/CCG/deck-builder/card-battler work, `review-isometric-production` for isometric or 2.5D production review, and `create-game-art-sheets` for sprites, tilesets, or animation sheets.
+- Convert references like named games, studios, artists, or franchises into original design adjectives and constraints, not copied layouts, characters, icons, or UI chrome.
+- Require style decisions to survive gameplay readability at small sizes, busy states, varied screens, and real implementation constraints.
+- Keep genre-specific rules in the matching skill or style contract instead of baking them into the generic art director role.
 
 # Constraints
 
-- Do not copy proprietary card frames, board layouts, logos, characters, named factions, UI chrome, or exact compositions from referenced games.
-- Do not make a one-note palette; warm fantasy should still include readable opposing accents and state colors.
-- Do not prioritize cinematic art over gameplay clarity for cards, tokens, counters, or board zones.
+- Do not default to card-game, TCG, isometric, pixel-art, or any other specialist domain unless the user request or repository context selects it.
+- Do not copy proprietary frames, boards, layouts, logos, characters, factions, iconography, UI chrome, or exact compositions from referenced games.
+- Do not make a one-note palette; every direction still needs hierarchy, contrast, state colors, and opposing accents where gameplay requires them.
+- Do not prioritize cinematic art over gameplay clarity, accessibility, asset production, or runtime constraints.
 - Do not accept vague "make it like X game" direction without translating it into original materials, shapes, palette, mood, and layout rules.
 - Do not store project-specific art decisions in OpenCaw unless the user explicitly asks to update the shared baseline.
 
 # Collaboration
 
-- Partner with `card-illustrator` to keep card art and frames aligned with the art bible.
-- Partner with `board-ui-artist` to ensure board zones and card placements remain readable.
-- Partner with `token-vfx-artist` to align token silhouettes, status markers, and VFX language.
-- Partner with `generative-art-designer` and `css-vector-artist` when moving between generated concepts and production UI/vector assets.
+- Partner with `game-designer` to align visual direction with mechanics, player fantasy, and interaction priorities.
+- Partner with `generative-art-designer` for concept exploration, prompt quality, and generated-asset sanity gates.
+- Partner with `css-vector-artist`, `frontend-developer`, and `qa-engineer` when art direction becomes implemented UI, responsive layout, or screenshot-verifiable acceptance criteria.
+- Partner with `card-illustrator`, `board-ui-artist`, and `token-vfx-artist` only when card-game or board-battle work is requested, and route that work through `tcg-art-direction`.
+- Partner with style-specific roles such as `isometric-2-5d-art-director`, `tile-set-artist`, `pixel-artist`, or `game-vfx-artist` when the selected game format needs their specialist constraints.
 - Partner with `qa-engineer` for visual sanity, responsive readability, and screenshot review.

--- a/.styles/ABYSSAL_MONSTER_GROTESQUE.md
+++ b/.styles/ABYSSAL_MONSTER_GROTESQUE.md
@@ -1,0 +1,24 @@
+# ABYSSAL_MONSTER_GROTESQUE.md
+
+## Intent
+
+Create grotesque dark-fantasy creature, boss, corruption, and transformation art built around tragic silhouettes, readable threat language, and unsettling material contrast.
+
+## Production Rules
+
+- Start with a strong readable silhouette before adding horns, limbs, cloth, bone, rot, smoke, chains, parasite forms, or armor remnants.
+- Use materials such as wet stone, old blood, cracked bone, tarnished metal, grave wax, burned cloth, ash, chitin, and corrupted flesh with controlled highlights.
+- Preserve gameplay readability through clear weak points, attack limbs, hurtboxes, gaze direction, status buildup, and telegraphed motion shapes.
+- Treat grotesque details as secondary texture; do not let surface noise obscure the creature's pose, scale, faction, or attack state.
+- Keep body horror stylized and purposeful, avoiding gratuitous gore when threat can be communicated through shape, posture, decay, and atmosphere.
+
+## Acceptance Checks
+
+- The creature reads clearly in idle, attack, staggered, damaged, and defeated states.
+- Boss scale, arena placement, and threat direction remain legible through fog, darkness, particles, and camera motion.
+- Grotesque detail supports lore and gameplay instead of becoming random visual noise.
+- Generated or sourced assets avoid copied commercial monsters, signature boss silhouettes, exact armor sets, and recognizable creature designs.
+
+## Role Fit
+
+Use with `art-director`, `illustrative-2d-artist`, `generative-art-designer`, `game-vfx-artist`, `cutout-rig-animator`, and `qa-engineer`.

--- a/.styles/ARCANE_ARENA_CLARITY.md
+++ b/.styles/ARCANE_ARENA_CLARITY.md
@@ -1,0 +1,24 @@
+# ARCANE_ARENA_CLARITY.md
+
+## Intent
+
+Create a clean, competitive TCG or card-battler style with mature fantasy polish, precise battlefield readability, and restrained magical spectacle.
+
+## Production Rules
+
+- Use disciplined materials such as polished stone, metal inlays, parchment, glass, controlled arcane light, and clean engraved borders.
+- Keep card frames flatter and more information-forward than ornate styles, with strong title, cost, type, rules, and stat areas.
+- Anchor hand, deck/library, graveyard/discard, exile/banish, stack/priority, targeting, and battlefield zones in stable readable positions.
+- Use concise VFX shapes such as rings, beams, arcs, pulses, and state glows that clarify actions without hiding card text or board counts.
+- Reserve highest contrast for playable decisions, targeting, priority prompts, lethal threats, and rules-relevant state.
+
+## Acceptance Checks
+
+- Cards remain readable in hand, deck preview, collection, and board-scale states.
+- Targeting, ownership, priority, graveyard/discard, and stack/resolution states are inspectable at a glance.
+- Fantasy polish does not introduce clutter that slows competitive scanning.
+- Named commercial TCG references have been translated into original materials, geometry, icons, and layout rules.
+
+## Role Fit
+
+Use with `art-director`, `card-illustrator`, `board-ui-artist`, `token-vfx-artist`, `css-vector-artist`, and `qa-engineer`. Route TCG-specific briefs through `tcg-art-direction`.

--- a/.styles/ASHEN_GOTHIC_FANTASY.md
+++ b/.styles/ASHEN_GOTHIC_FANTASY.md
@@ -1,0 +1,24 @@
+# ASHEN_GOTHIC_FANTASY.md
+
+## Intent
+
+Create bleak gothic fantasy art with ash, stone, candlelight, ruined grandeur, solemn silhouettes, and readable heroic struggle inside oppressive worlds.
+
+## Production Rules
+
+- Use restrained palettes built from ash gray, soot black, old ivory, desaturated brass, dried blood, cold blue shadow, and small warm candle or ember accents.
+- Define architecture with pointed arches, worn statues, bell towers, crypts, buttresses, broken saints, scorched banners, grave markers, and weathered stone.
+- Keep character and enemy silhouettes strong against fog, ruins, smoke, rain, and low-value backgrounds.
+- Use lighting sparingly: candles, embers, moon shafts, stained-glass color, altar glow, and distant fires should guide attention without flattening mood.
+- Make decay feel historical and material-specific: cracked masonry, oxidized metal, torn cloth, worn leather, old bone, ash buildup, and damp soot.
+
+## Acceptance Checks
+
+- Characters, enemies, interactables, hazards, and pickups remain readable in dark scenes.
+- Gothic details support navigation, encounter staging, lore, and atmosphere instead of filling every surface.
+- Warm accents are reserved for focus, danger, refuge, magic, or reward.
+- Named commercial references have been translated into original architecture, silhouettes, materials, symbols, and encounter staging.
+
+## Role Fit
+
+Use with `art-director`, `isometric-2-5d-art-director`, `illustrative-2d-artist`, `pre-rendered-2-5d-artist`, `parallax-background-artist`, and `game-vfx-artist`.

--- a/.styles/CATHEDRAL_SHADOW_HORROR.md
+++ b/.styles/CATHEDRAL_SHADOW_HORROR.md
@@ -1,0 +1,24 @@
+# CATHEDRAL_SHADOW_HORROR.md
+
+## Intent
+
+Create sacred, oppressive dark-fantasy horror built from monumental interiors, ritual spaces, deep shadow, stained light, and unsettling stillness.
+
+## Production Rules
+
+- Build spaces around vaulted ceilings, long aisles, altars, reliquaries, crypt stairs, confession booths, hanging chains, censers, candles, and broken iconography.
+- Use high vertical scale and compressed player-scale foregrounds to make interiors feel ancient, heavy, and threatening.
+- Control contrast with large shadow masses, narrow light shafts, stained-glass color, smoke, dust, and localized glow.
+- Keep gameplay paths, interactables, bosses, traps, doors, ladders, and hazards readable through clear edge lighting and silhouette breaks.
+- Use religious or ritual motifs as original fictional iconography; avoid copying real-world sacred symbols in a way that creates accidental branding or offense.
+
+## Acceptance Checks
+
+- Navigation and combat readability survive deep shadow, fog, candlelight, and high-detail architecture.
+- Ritual props and environmental storytelling have a coherent symbolic language.
+- Large-scale interiors do not hide doors, interactables, enemies, or objective cues.
+- Horror mood comes from space, scale, lighting, silence, and material decay rather than unreadable darkness.
+
+## Role Fit
+
+Use with `art-director`, `parallax-background-artist`, `illustrative-2d-artist`, `pre-rendered-2-5d-artist`, `game-vfx-artist`, and `qa-engineer`.

--- a/.styles/CURSED_RELIC_BAROQUE.md
+++ b/.styles/CURSED_RELIC_BAROQUE.md
@@ -1,0 +1,24 @@
+# CURSED_RELIC_BAROQUE.md
+
+## Intent
+
+Create ornate cursed-fantasy art with tarnished luxury, relic materials, aristocratic decay, ritual ornament, and controlled visual excess.
+
+## Production Rules
+
+- Use materials such as tarnished gold, blackened silver, cracked enamel, velvet, bone, wax seals, old parchment, blood-red lacquer, oxidized bronze, and smoky gemstones.
+- Make ornament meaningful by tying filigree, halos, crowns, masks, seals, script, and relic shapes to factions, status, rarity, or lore.
+- Balance detail density with clear silhouettes, readable UI regions, readable equipment shapes, and clean interaction states.
+- Use asymmetry, cracks, missing jewels, scorched fabric, and corrosion to show corruption without making assets look randomly damaged.
+- Reserve the most elaborate ornament for bosses, relics, sacred objects, elite armor, rare rewards, and major UI moments.
+
+## Acceptance Checks
+
+- Ornate detail remains legible after downscaling, compression, lighting changes, and placement in busy scenes.
+- Relic, armor, UI, item, and faction treatments share a coherent material grammar.
+- Luxury and corruption do not erase gameplay states, item tiers, or affordances.
+- No commercial crests, item shapes, armor silhouettes, fonts, or UI frames are copied from named references.
+
+## Role Fit
+
+Use with `art-director`, `css-vector-artist`, `card-illustrator`, `illustrative-2d-artist`, `generative-art-designer`, and `game-vfx-artist`.

--- a/.styles/HEROIC_FACTION_FANTASY.md
+++ b/.styles/HEROIC_FACTION_FANTASY.md
@@ -1,0 +1,24 @@
+# HEROIC_FACTION_FANTASY.md
+
+## Intent
+
+Create faction-driven TCG or card-battler art with bold heroes, banners, creatures, relics, spells, and readable visual identity across sets.
+
+## Production Rules
+
+- Define faction shape language, materials, emblem rules, palette accents, spell colors, creature silhouettes, and rarity treatments.
+- Use banners, armor, carved wood, stone, cloth, heraldry, relic metals, and environmental motifs without copying proprietary faction marks.
+- Keep faction identity visible in card frames, board wells, tokens, status markers, card backs, and set-level promotional art.
+- Distinguish card types through composition and materials so creatures, spells, weapons, relics, locations, heroes, and secrets read differently.
+- Limit emblem complexity so faction symbols do not compete with cost, type, stats, targeting, or state markers.
+
+## Acceptance Checks
+
+- Each faction is recognizable through more than color alone.
+- Card art, frames, board UI, tokens, and VFX share one coherent faction grammar.
+- Rarity and faction cues support gameplay meaning instead of becoming arbitrary decoration.
+- Generated or sourced assets avoid copied characters, logos, symbols, frames, and faction identities.
+
+## Role Fit
+
+Use with `art-director`, `card-illustrator`, `board-ui-artist`, `token-vfx-artist`, `illustrative-2d-artist`, and `generative-art-designer`. Route TCG-specific briefs through `tcg-art-direction`.

--- a/.styles/INDEX.md
+++ b/.styles/INDEX.md
@@ -2,8 +2,12 @@
 
 Available OpenCaw art style templates:
 
+- ABYSSAL_MONSTER_GROTESQUE
 - ARCANE_ARENA_CLARITY
+- ASHEN_GOTHIC_FANTASY
+- CATHEDRAL_SHADOW_HORROR
 - CEL_SHADED_COMIC
+- CURSED_RELIC_BAROQUE
 - CUTOUT_RIGGED
 - DOODLE_SKETCH
 - FLAT_MINIMALIST
@@ -20,6 +24,7 @@ Available OpenCaw art style templates:
 - PARALLAX_BACKGROUND
 - PIXEL_ART
 - PRE_RENDERED_2_5D
+- RUINED_MEDIEVAL_REALISM
 - SCIENCE_FANTASY
 - TACTICAL_UI_HUD
 - TILESET_ENVIRONMENT
@@ -33,6 +38,7 @@ Use one or more of these when generating `../STYLE.md` for a host repository.
 - Isometric tactics, town builders, ARPGs, and 2.5D exploration: `ISOMETRIC_2_5D`
 - Pixel games: `PIXEL_ART` plus `TILESET_ENVIRONMENT`
 - Hand-painted games: `HAND_DRAWN_ILLUSTRATIVE` or `PAINTERLY_2D`
+- Dark fantasy, gothic ruins, cursed medieval worlds, and boss-heavy horror: start with one of `ASHEN_GOTHIC_FANTASY`, `RUINED_MEDIEVAL_REALISM`, `CATHEDRAL_SHADOW_HORROR`, `CURSED_RELIC_BAROQUE`, or `ABYSSAL_MONSTER_GROTESQUE`, then add `PAINTERLY_2D`, `PRE_RENDERED_2_5D`, `GAME_VFX`, or `TACTICAL_UI_HUD` as needed
 - UI-heavy games: `TACTICAL_UI_HUD` plus `VECTOR_UI`
 - TCG, CCG, deck-builder, and card-battler games: start with one of `WARM_TAVERN_FANTASY`, `ARCANE_ARENA_CLARITY`, `MYTHIC_GODFORGE`, `HEROIC_FACTION_FANTASY`, or `SCIENCE_FANTASY`, then add `TACTICAL_UI_HUD`, `VECTOR_UI`, `PAINTERLY_2D`, or `GAME_VFX` as needed
 - Animation-heavy characters: `CUTOUT_RIGGED`

--- a/.styles/INDEX.md
+++ b/.styles/INDEX.md
@@ -2,6 +2,7 @@
 
 Available OpenCaw art style templates:
 
+- ARCANE_ARENA_CLARITY
 - CEL_SHADED_COMIC
 - CUTOUT_RIGGED
 - DOODLE_SKETCH
@@ -10,16 +11,20 @@ Available OpenCaw art style templates:
 - GEOMETRIC_SHAPE
 - HAND_DRAWN_ILLUSTRATIVE
 - HD_2D
+- HEROIC_FACTION_FANTASY
 - ISOMETRIC_2_5D
 - LOW_POLY_2_5D
 - MONOCHROME_LIMITED_PALETTE
+- MYTHIC_GODFORGE
 - PAINTERLY_2D
 - PARALLAX_BACKGROUND
 - PIXEL_ART
 - PRE_RENDERED_2_5D
+- SCIENCE_FANTASY
 - TACTICAL_UI_HUD
 - TILESET_ENVIRONMENT
 - VECTOR_UI
+- WARM_TAVERN_FANTASY
 
 Use one or more of these when generating `../STYLE.md` for a host repository.
 
@@ -29,6 +34,7 @@ Use one or more of these when generating `../STYLE.md` for a host repository.
 - Pixel games: `PIXEL_ART` plus `TILESET_ENVIRONMENT`
 - Hand-painted games: `HAND_DRAWN_ILLUSTRATIVE` or `PAINTERLY_2D`
 - UI-heavy games: `TACTICAL_UI_HUD` plus `VECTOR_UI`
+- TCG, CCG, deck-builder, and card-battler games: start with one of `WARM_TAVERN_FANTASY`, `ARCANE_ARENA_CLARITY`, `MYTHIC_GODFORGE`, `HEROIC_FACTION_FANTASY`, or `SCIENCE_FANTASY`, then add `TACTICAL_UI_HUD`, `VECTOR_UI`, `PAINTERLY_2D`, or `GAME_VFX` as needed
 - Animation-heavy characters: `CUTOUT_RIGGED`
 - Sprite-rendered 3D pipelines: `PRE_RENDERED_2_5D` or `HD_2D`
 - Effects-heavy combat or magic: `GAME_VFX`

--- a/.styles/MYTHIC_GODFORGE.md
+++ b/.styles/MYTHIC_GODFORGE.md
@@ -1,0 +1,24 @@
+# MYTHIC_GODFORGE.md
+
+## Intent
+
+Create a divine, mythic, high-stakes TCG or card-battler style built from monumental materials, sacred light, dramatic silhouettes, and readable power hierarchy.
+
+## Production Rules
+
+- Use materials such as marble, obsidian, gold, celestial stone, molten light, engraved relics, ash, starlight, and sacred geometry.
+- Give mythic cards stronger crowns, halos, frame breaks, rarity reveals, and dramatic focal lighting while preserving rules text and thumbnail crops.
+- Treat board zones as altars, arenas, vaults, voids, temples, or celestial planes with clear hand, deck, graveyard, exile, and token anchors.
+- Use VFX with radiant eruptions, sigils, constellation trails, ash, impact timing, and divine color language proportional to gameplay importance.
+- Balance gold, glow, and dark materials with enough value contrast that card states and token stats remain readable.
+
+## Acceptance Checks
+
+- Mythic spectacle does not obscure costs, stats, card names, targeting, graveyard counts, or active prompts.
+- Tokens and creatures have distinct silhouettes before particles or glow are added.
+- Gold, white, black, and glow-heavy palettes still meet contrast and state-readability expectations.
+- Divine inspiration remains original and does not copy named pantheons, logos, characters, or commercial game frames unless owned by the user.
+
+## Role Fit
+
+Use with `art-director`, `card-illustrator`, `token-vfx-artist`, `board-ui-artist`, `game-vfx-artist`, and `painterly-2d-artist`. Route TCG-specific briefs through `tcg-art-direction`.

--- a/.styles/RUINED_MEDIEVAL_REALISM.md
+++ b/.styles/RUINED_MEDIEVAL_REALISM.md
@@ -1,0 +1,24 @@
+# RUINED_MEDIEVAL_REALISM.md
+
+## Intent
+
+Create grounded dark-medieval fantasy art with battered armor, ruined castles, practical weapons, weathered settlements, and believable material wear.
+
+## Production Rules
+
+- Favor plausible construction, weight, wear, and maintenance for armor, weapons, doors, ladders, siege props, roads, ruins, and settlements.
+- Use materials such as iron, steel, chainmail, leather, wool, linen, mud, rain-dark wood, stone, moss, old mortar, straw, and soot-blackened firelight.
+- Keep heroic and enemy silhouettes readable through cloak shapes, helmet profiles, weapon stance, shield forms, and armor massing.
+- Make ruins navigable through clear path edges, broken wall language, climbable surfaces, blocked routes, hazards, and readable landmarks.
+- Use grime and damage selectively; every scratch, dent, stain, and collapse should support age, use, class, conflict, or environment.
+
+## Acceptance Checks
+
+- Weapons, armor, props, and architecture feel grounded without becoming visually dull or muddy.
+- Player paths, enemy threats, pickups, hazards, and interactables remain readable in rain, fog, mud, firelight, and ruins.
+- Material aging is consistent across characters, environments, UI props, and key items.
+- The style does not copy recognizable armor sets, weapon designs, castle layouts, or boss-arena compositions from commercial references.
+
+## Role Fit
+
+Use with `art-director`, `tile-set-artist`, `isometric-2-5d-environment-artist`, `pre-rendered-2-5d-artist`, `illustrative-2d-artist`, and `qa-engineer`.

--- a/.styles/SCIENCE_FANTASY.md
+++ b/.styles/SCIENCE_FANTASY.md
@@ -1,0 +1,24 @@
+# SCIENCE_FANTASY.md
+
+## Intent
+
+Create a science-fantasy TCG or card-battler style that blends arcane systems, ships, machines, sky realms, relic technology, and readable card-game structure.
+
+## Production Rules
+
+- Combine fantasy materials with technical cues such as brass, enamel, glass, star maps, gauges, runed metal, engine glow, sky stone, and arcane circuitry.
+- Keep card frames original by mixing magical framing with instruments, lenses, vents, maps, terminals, or artifact mechanisms.
+- Treat board zones as star charts, hangar tables, floating lanes, workshop surfaces, or spell-tech arenas with stable deck and discard anchors.
+- Use token silhouettes for drones, constructs, ships, familiars, engines, artifacts, and elemental machines with clear ownership and stat bases.
+- Use VFX such as spell-tech arcs, thruster glows, runic targeting, energized shields, scan lines, and mechanical impact beats without drifting into pure neon cyberpunk unless requested.
+
+## Acceptance Checks
+
+- Technology and magic remain visually integrated rather than split into unrelated themes.
+- Deck, graveyard/discard, targeting, ownership, resource, and token states remain inspectable.
+- Mechanical detail does not collapse into noise at card or token scale.
+- References to known sci-fi or fantasy games are translated into original material, shape, palette, and interaction rules.
+
+## Role Fit
+
+Use with `art-director`, `card-illustrator`, `board-ui-artist`, `token-vfx-artist`, `game-vfx-artist`, `css-vector-artist`, and `generative-art-designer`. Route TCG-specific briefs through `tcg-art-direction`.

--- a/.styles/WARM_TAVERN_FANTASY.md
+++ b/.styles/WARM_TAVERN_FANTASY.md
@@ -1,0 +1,24 @@
+# WARM_TAVERN_FANTASY.md
+
+## Intent
+
+Create a warm, tactile, readable fantasy TCG or card-battler style with tabletop charm, inviting materials, playful magic, and clear game-state hierarchy.
+
+## Production Rules
+
+- Use cozy materials such as carved wood, aged brass, leather, enamel, warm stone, soft cloth, glowing crystals, waxed parchment, and friendly magical light.
+- Keep card frames dimensional and chunky enough to feel collectible while preserving clean areas for title, cost, type, rules, stats, rarity, and state.
+- Treat the board as a readable tabletop system with clear hand, deck/library, discard/graveyard, battlefield, resource, secret/trap, and player/opponent zones.
+- Use rounded token silhouettes, bold bases, expressive poses, and short VFX beats such as sparks, puffs, glows, impacts, and settle animations.
+- Include opposing accents and state colors so warmth does not become a one-note brown, orange, or gold palette.
+
+## Acceptance Checks
+
+- Cards read clearly in hand, deck, graveyard/discard, board, and collection contexts.
+- Deck and graveyard/discard piles are visually distinct by shape, tilt, count badges, and state effects.
+- Tokens, ownership, counters, buffs, debuffs, and targeting do not rely on color alone.
+- The direction is original and does not copy named commercial card frames, boards, heroes, mana icons, card backs, logos, or UI chrome.
+
+## Role Fit
+
+Use with `art-director`, `card-illustrator`, `board-ui-artist`, `token-vfx-artist`, `illustrative-2d-artist`, and `generative-art-designer`. Route TCG-specific briefs through `tcg-art-direction`.

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ use role fullstack-engineer and build a calculator app with a simple UI, basic a
 ```
 
 ```text
-use role art-director and create an original Hearthstone-like warm fantasy card-game art bible with cards in hand, deck, graveyard, board tokens, and VFX guidance
+use role art-director and create a reusable art bible for this game, including visual language, asset categories, style constraints, specialist skill routing, and validation checks
 ```
 
 ```text
@@ -422,7 +422,7 @@ Examples:
 - `fullstack-engineer` → end-to-end feature delivery, API/UI integration, full-flow verification
 - `security-engineer` → threat modeling, security audits, dependency vulnerability review
 - `sre` → incident analysis, resilience design, performance review
-- `art-director` → TCG art bible, card/board/token style direction, and IP-safe genre translation
+- `art-director` → general game art bible, visual language, production constraints, and routing to specialist art skills when a specific game format is requested
 
 Multi-role sessions should merge bindings in the same order as the requested roles.
 


### PR DESCRIPTION
## Summary

Generalizes the `art-director` role and expands the reusable style catalog with generic card-game and dark-fantasy style families.

## What changed

- Made `arts/art-director` a generic game art director instead of a TCG-specific role.
- Updated `art-director` aliases, collaboration guidance, and default role skill bindings.
- Kept `tcg-art-direction` available as conditional specialist routing when card-game, TCG, CCG, deck-builder, or card-battler work is requested.
- Added card-game-relevant style templates with generic style names:
  - `ARCANE_ARENA_CLARITY`
  - `HEROIC_FACTION_FANTASY`
  - `MYTHIC_GODFORGE`
  - `SCIENCE_FANTASY`
  - `WARM_TAVERN_FANTASY`
- Added dark-fantasy style templates with generic style names:
  - `ABYSSAL_MONSTER_GROTESQUE`
  - `ASHEN_GOTHIC_FANTASY`
  - `CATHEDRAL_SHADOW_HORROR`
  - `CURSED_RELIC_BAROQUE`
  - `RUINED_MEDIEVAL_REALISM`
- Updated `.styles/INDEX.md`, `.roles/INDEX.md`, role skill maps, and README examples.

## Why

The generic role and style catalogs should be referenced by reusable role or art-style names, not by a specific game type, source game, or implementation purpose. Specialist skills remain available through contextual routing when a request calls for them.

## Risks

- Prompts that relied on `art-director` always loading `tcg-art-direction` should now include card-game/TCG context so the specialist routing applies.
- The new style templates are baseline guidance only; project-specific art direction still belongs in the host repository style contract.

## Validation

- `bash ./commands/validate-opencaw.sh` passed.
- `bash ./commands/resolve-role.sh art-director` resolved `arts/art-director` by exact name.
- `bash ./commands/resolve-role.sh style-director` resolved `arts/art-director` by alias.
- `bash ./commands/resolve-role.sh game-art-director` resolved `arts/art-director` by alias.
- Confirmed no `TCG_` style names were introduced.
- Confirmed no source game or soulslike names were introduced into the new style catalog content.

## Deployment / rollback notes

- No deployment impact; this is a baseline role/style/documentation change.
- Rollback is a clean revert of the PR if the catalog direction needs to be revised.