### PR TITLE
fix(memory): complete post-merge Memory v2 QA

### DIFF
--- a/.ai/REPO_MAP.md
+++ b/.ai/REPO_MAP.md
@@ -1,6 +1,6 @@
 # Repository Map
 
-<!-- OPENCAW_REPO_MAP_FINGERPRINT: 2b7089cdd83ae7e0470c897d6d57a780136c4969e540982f81f6bedc16c84b9e -->
+<!-- OPENCAW_REPO_MAP_FINGERPRINT: aafc0043278d3bc753c78ebfb7d60449a6d082026e79a18421c636647caaa04b -->
 
 - [kind:component] [scope:core] `AGENTS.md` is the authoritative OpenCaw baseline contract for startup, memory, task, verification, and delivery behavior.
 - [kind:component] [area:commands] [tech:bash] `commands/` contains deterministic executable workflows; `commands/lib/memory-common.sh` centralizes Memory v2 path, schema, safety, archive, and fingerprint behavior.

--- a/.ai/tasks/OPEN_ISSUES.md
+++ b/.ai/tasks/OPEN_ISSUES.md
@@ -1,1 +1,0 @@
-https://github.com/TimothyMeadows/OpenCaw/issues/72

--- a/commands/comment-pr-qa-results.sh
+++ b/commands/comment-pr-qa-results.sh
@@ -130,7 +130,12 @@ $summary_text
 $inline_or_artifact_block
 EOF
 
-"$GH_BIN" pr comment "$pr_ref" --body-file "$comment_file" >/dev/null
+gh_comment_file="$comment_file"
+if [[ "${GH_BIN,,}" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+  gh_comment_file="$(wslpath -w "$comment_file")"
+fi
+
+"$GH_BIN" pr comment "$pr_ref" --body-file "$gh_comment_file" >/dev/null
 
 popd >/dev/null
 

--- a/tests/test-memory-system.sh
+++ b/tests/test-memory-system.sh
@@ -160,6 +160,32 @@ grep -q '## Tag Catalog' "$project/.ai/CONTEXT_SUMMARY.md" || fail 'summary omit
 ! grep -q 'Billing fixture fact' "$project/.ai/CONTEXT_SUMMARY.md" || fail 'summary copied arbitrary memory content'
 
 echo '[9/9] checking command syntax and repository validation hooks'
+fake_gh_dir="$temp_root/fake-gh"
+fake_gh_log="$temp_root/fake-gh.log"
+fake_qa_summary="$temp_root/fake-qa-summary.md"
+mkdir -p "$fake_gh_dir"
+cat > "$fake_gh_dir/gh.exe" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-} ${2:-}" == 'pr view' ]]; then
+  echo 'https://github.com/example/project/pull/73'
+  exit 0
+fi
+if [[ "${1:-} ${2:-}" == 'pr comment' ]]; then
+  while [[ $# -gt 0 ]]; do
+    if [[ "$1" == '--body-file' ]]; then
+      printf '%s\n' "${2:-}" > "$OPENCAW_TEST_GH_LOG"
+      exit 0
+    fi
+    shift
+  done
+fi
+exit 1
+EOF
+chmod +x "$fake_gh_dir/gh.exe"
+printf '# QA\n\nPASS\n' > "$fake_qa_summary"
+PATH="$fake_gh_dir:/usr/bin:/bin" OPENCAW_TEST_GH_LOG="$fake_gh_log" run_for "$project" bash commands/comment-pr-qa-results.sh 73 "$fake_qa_summary" >/dev/null
+grep -Eq '^([A-Za-z]:\\|\\\\)' "$fake_gh_log" || fail 'Windows gh.exe did not receive a translated body-file path'
 bash -n commands/lib/memory-common.sh commands/*memory*.sh commands/query-project-context.sh commands/repo-map-status.sh commands/resolve-opencaw-paths.sh
 bash commands/validate-commands.sh >/dev/null
 bash commands/validate-skills.sh >/dev/null


### PR DESCRIPTION
## Summary

Complete the post-merge Memory v2 QA fixes discovered after #73 was merged.

Follow-up to #73 and #72.

## What changed

- Refresh `.ai/REPO_MAP.md` with the fingerprint of the now-tracked Memory v2 repository structure.
- Translate temporary PR-comment body files from WSL paths to Windows paths when OpenCaw invokes `gh.exe`.
- Add regression coverage using an isolated fake `gh.exe` to prove `--body-file` receives a Windows-compatible path.

## Why

PR #73 was merged before post-PR QA finished. QA then found that the repository map was stale after the new paths became tracked, and that Windows `gh.exe` could not open a WSL `/tmp` comment body path.

## Validation

- `bash tests/test-memory-system.sh`
- `bash commands/validate-opencaw.sh`
- `bash commands/validate-memory.sh`
- `bash commands/repo-map-status.sh` reports `CURRENT`
- `git diff --check`

All checks passed.

## Deployment and rollback

No deployment action is required. Revert the two follow-up commits to roll back.
