### PR TITLE
feat(scaffold): add Windows Bash bootstrap

### DIFF
--- a/.ai/MEMORY.md
+++ b/.ai/MEMORY.md
@@ -4,3 +4,4 @@
 - [kind:gotcha] [env:wsl] [env:windows] [topic:path-translation] OpenCaw validation can run under WSL while Node.js, Git, Playwright, and FFmpeg resolve as Windows executables; translate paths only at the runtime boundary and preserve already-native Windows paths.
 - [kind:architecture] [area:memory] [tech:bash] Memory v2 keeps all memory artifacts under `<project-root>/.ai/`: always-loaded constraints in `SYSTEM_MEMORY.md`, tagged facts in `MEMORY.md`, and semantic structure in `REPO_MAP.md`.
 - [kind:convention] [area:commands] [topic:path-boundaries] Commands that write project artifacts resolve the active project through `commands/lib/memory-common.sh` and fail closed when the repository boundary is ambiguous.
+- [kind:workflow] [env:windows] [tech:powershell] Use `commands/install-windows-bash.ps1` to prefer existing native Git Bash, explicitly install Git Bash or WSL, and invoke the Bash scaffold; Linux and macOS do not use this bootstrap.

--- a/.ai/REPO_MAP.md
+++ b/.ai/REPO_MAP.md
@@ -1,6 +1,6 @@
 # Repository Map
 
-<!-- OPENCAW_REPO_MAP_FINGERPRINT: aafc0043278d3bc753c78ebfb7d60449a6d082026e79a18421c636647caaa04b -->
+<!-- OPENCAW_REPO_MAP_FINGERPRINT: e98c54e0cbf05e564ae8f76561ff4a8279424edbcee76a13ed87c156f9e3ad9f -->
 
 - [kind:component] [scope:core] `AGENTS.md` is the authoritative OpenCaw baseline contract for startup, memory, task, verification, and delivery behavior.
 - [kind:component] [area:commands] [tech:bash] `commands/` contains deterministic executable workflows; `commands/lib/memory-common.sh` centralizes Memory v2 path, schema, safety, archive, and fingerprint behavior.
@@ -9,3 +9,4 @@
 - [kind:test] [area:memory] [tech:bash] `tests/test-memory-system.sh` verifies root isolation, system and tagged memory, migration, retrieval, purge, replacement, cleanup, and repository-map freshness.
 - [kind:test] [scope:core] [tech:bash] `commands/validate-opencaw.sh` is the integrated structural validation entry point.
 - [kind:command] [area:memory] [tech:bash] `commands/query-project-context.sh` lists tags and retrieves ranked memory and repository-map entries before raw searches.
+- [kind:command] [area:scaffold] [env:windows] [tech:powershell] `commands/install-windows-bash.ps1` discovers native Git Bash or WSL, performs only explicitly requested installation, and can invoke `create-host-ai-scaffold.sh` through the selected provider.

--- a/.ai/RULES.md
+++ b/.ai/RULES.md
@@ -2,3 +2,4 @@
 
 - Before installing a dependency for OpenCaw work, record a lightweight audit of its source, selected version, lifecycle scripts, and known vulnerability result; keep reusable commands non-self-installing.
 - Keep every OpenCaw memory and context artifact under `<project-root>/.ai/`; never redirect memory storage to a user-home, machine-global, or workspace-parent directory.
+- Windows bootstrap commands must never install Bash implicitly; require the explicit `-Install` switch and support `-WhatIf` previews.

--- a/.ai/WINDOWS_BASH.md
+++ b/.ai/WINDOWS_BASH.md
@@ -1,0 +1,33 @@
+# Windows Bash Setup
+
+OpenCaw commands use Bash. On Windows, prefer Git Bash for native Windows filesystem performance; use WSL when Linux tool compatibility is more important.
+
+The scaffold never installs software automatically. Run these commands from the repository root in PowerShell.
+
+## Check for an existing provider
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "./commands/install-windows-bash.ps1"
+```
+
+## Install native Git Bash (recommended)
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "./commands/install-windows-bash.ps1" -Provider GitBash -Install
+```
+
+## Install WSL Bash
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "./commands/install-windows-bash.ps1" -Provider WSL -Install
+```
+
+WSL installation can require elevation or a restart.
+
+## Run the OpenCaw scaffold
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "./commands/install-windows-bash.ps1" -Provider GitBash -RunScaffold -ProjectRoot .
+```
+
+Linux and macOS should run `./commands/create-host-ai-scaffold.sh` directly; this Windows bootstrap is not needed there.

--- a/.ai/tasks/OPEN_ISSUES.md
+++ b/.ai/tasks/OPEN_ISSUES.md
@@ -1,0 +1,1 @@
+https://github.com/TimothyMeadows/OpenCaw/issues/75

--- a/.ai/tasks/TODO.md
+++ b/.ai/tasks/TODO.md
@@ -2,3 +2,4 @@
 
 1. [x] OpenCaw Memory v2 (`.ai/tasks/memory-v2/TASK.md`)
 2. [x] Correct system-memory storage to repository-local `.ai` (`.ai/tasks/memory-v2-repository-local-system-memory/TASK.md`)
+3. [x] Add Windows Bash bootstrap and scaffold guidance (`.ai/tasks/windows-bash-bootstrap/TASK.md`)

--- a/.ai/tasks/windows-bash-bootstrap/TASK.md
+++ b/.ai/tasks/windows-bash-bootstrap/TASK.md
@@ -1,0 +1,11 @@
+# Windows Bash bootstrap and scaffold guidance
+
+## Status
+Archived on 20260726T015606Z.
+
+## Archive
+- /mnt/c/Repository/OpenCaw/.ai/archive/tasks/windows-bash-bootstrap-20260726T015606Z.md
+
+## Durable Summary
+- Goal: Provide a Windows-first bootstrap that can discover or explicitly install a usable Bash runtime and then invoke the existing OpenCaw scaffold, while leaving Linux and macOS behavior unchanged.
+- Review: `commands/install-windows-bash.ps1` prefers native Git Bash, supports explicit `winget` Git installation or `wsl.exe --install`, and never installs without `-Install`.

--- a/.roles/ROLE_SKILL_MAP.json
+++ b/.roles/ROLE_SKILL_MAP.json
@@ -1,7 +1,7 @@
 {
   "__shared__": {
     "skills": ["create-task-file", "manage-task-issues", "maintain-memory", "maintain-repository-map", "clean-context", "pr-readiness-gate", "link-pr-to-task-issue", "post-pr-qa", "record-correction-pattern", "record-debug-resolution", "verify-and-explain"],
-    "commands": ["commands/create-task-file.sh", "commands/create-task-issue.sh", "commands/import-task-from-issue.sh", "commands/sync-task-issues.sh", "commands/resolve-opencaw-paths.sh", "commands/query-project-context.sh", "commands/append-project-memory.sh", "commands/append-system-memory.sh", "commands/repo-map-status.sh", "commands/validate-memory.sh", "commands/pr-readiness-check.sh", "commands/link-pr-to-task-issue.sh", "commands/comment-pr-qa-results.sh", "commands/update-todo-checklist.sh"]
+    "commands": ["commands/create-task-file.sh", "commands/create-task-issue.sh", "commands/import-task-from-issue.sh", "commands/sync-task-issues.sh", "commands/resolve-opencaw-paths.sh", "commands/install-windows-bash.ps1", "commands/query-project-context.sh", "commands/append-project-memory.sh", "commands/append-system-memory.sh", "commands/repo-map-status.sh", "commands/validate-memory.sh", "commands/pr-readiness-check.sh", "commands/link-pr-to-task-issue.sh", "commands/comment-pr-qa-results.sh", "commands/update-todo-checklist.sh"]
   },
   "arts/art-director": {
     "skills": ["maintain-art-style-contract", "develop-original-brand-directions", "design-ui-from-constraints", "source-licensed-visual-assets", "audit-reference-originality", "prepare-game-art-handoff", "iterate-art-to-sanity", "enforce-art-language-safety"],

--- a/.roles/ROLE_SKILL_MAP.md
+++ b/.roles/ROLE_SKILL_MAP.md
@@ -27,6 +27,7 @@ Role mappings use domain-qualified identifiers. Shared capabilities apply after 
 - `commands/import-task-from-issue.sh`
 - `commands/sync-task-issues.sh`
 - `commands/resolve-opencaw-paths.sh`
+- `commands/install-windows-bash.ps1`
 - `commands/query-project-context.sh`
 - `commands/append-project-memory.sh`
 - `commands/append-system-memory.sh`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,8 @@ Never write project-specific learned state into this mounted baseline unless the
 ## Session startup review
 At session start, follow this memory-first sequence:
 
+On Windows without a usable Bash runtime, run the PowerShell bootstrap described in **Windows Bash bootstrap** before this sequence.
+
 1. Resolve the project root and repository-local `.ai` paths with `./commands/resolve-opencaw-paths.sh`.
 2. Run `./commands/create-host-ai-scaffold.sh` automatically when required files are missing. The command is idempotent and reports legacy-memory migration needs.
 3. Load all of `SYSTEM_MEMORY.md`. It has precedence over project memory and rules, but never over actual system, developer, or current user instructions.
@@ -35,6 +37,16 @@ At session start, follow this memory-first sequence:
 7. If legacy memory is reported, prepare and complete the AI-classified migration before loading untagged entries. Never load legacy memory as a fallback.
 
 You should send a message to the user that you are an OpenCaw session and ready for usage.
+
+## Windows Bash bootstrap
+
+- Linux and macOS use their existing Bash runtime; do not run Windows bootstrap or installation logic there.
+- On Windows, prefer an existing Git Bash runtime for native filesystem performance and lower startup overhead.
+- If Bash is missing, run `powershell -NoProfile -ExecutionPolicy Bypass -File "./<mount>/commands/install-windows-bash.ps1"` to inspect providers.
+- Install software only when the user explicitly requests it or runs the installer with `-Install`; never install Bash during ordinary scaffold creation.
+- Use `-Provider GitBash -Install` for the recommended native Windows provider or `-Provider WSL -Install` when Linux tooling compatibility is required.
+- Use `-RunScaffold -ProjectRoot <path>` after discovery or installation to invoke the canonical Bash scaffold.
+- The scaffold writes `.ai/WINDOWS_BASH.md` only when it detects a Windows host, Git Bash/MSYS/Cygwin, or WSL.
 
 ## Architecture workflow
 The canonical architecture contract for the host repository is:

--- a/README.md
+++ b/README.md
@@ -72,6 +72,34 @@ After forking, use **your fork URL** in all installation commands instead of the
 
 OpenCaw can be installed in an existing repository in two primary ways.
 
+## Windows Bash prerequisite
+
+OpenCaw commands use Bash. Linux and macOS already provide the expected shell and do not need this Windows bootstrap.
+
+On Windows, Git Bash is recommended because it runs natively against Windows paths and normally starts faster than crossing the WSL filesystem boundary. After OpenCaw exists at `.codex` (replace the mount name for `.cursor` or `.claude`), inspect the available provider from PowerShell:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\.codex\commands\install-windows-bash.ps1"
+```
+
+Install Git Bash explicitly when it is missing:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\.codex\commands\install-windows-bash.ps1" -Provider GitBash -Install
+```
+
+Or install WSL when Linux compatibility is preferred:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\.codex\commands\install-windows-bash.ps1" -Provider WSL -Install
+```
+
+Installation is never automatic. Preview installation or scaffold execution with `-WhatIf`. Once a provider is available, run the canonical scaffold through it:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File ".\.codex\commands\install-windows-bash.ps1" -Provider GitBash -RunScaffold -ProjectRoot .
+```
+
 ## Option 1 — Git Submodule (Recommended)
 
 Submodules allow the instruction system to be updated centrally while individual projects control the version they use.
@@ -946,6 +974,7 @@ run command dotnet-build
 | `comment-issue-test-results.sh` | Post QA/Playwright results and screenshot references to issue |
 | `clean-context.sh` | Compress context and refresh high-signal summaries |
 | `resolve-opencaw-paths.sh` | Resolve safe project-local `.ai` memory paths |
+| `install-windows-bash.ps1` | Discover or explicitly install Git Bash/WSL and run the OpenCaw scaffold on Windows |
 | `append-system-memory.sh` | Add a validated repository-local system-memory entry |
 | `append-project-memory.sh` | Add or replace a validated tagged project-memory entry |
 | `query-project-context.sh` | List tags or retrieve ranked relevant memory and repository-map entries |

--- a/commands/SCHEMA.md
+++ b/commands/SCHEMA.md
@@ -8,17 +8,23 @@ Commands represent **deterministic execution steps**, typically shell scripts.
 
 # Required Structure
 
-Commands must exist at:
+Portable commands normally exist at:
 
 ```
 commands/<command-name>.sh
+```
+
+Windows bootstrap commands that must run before Bash is available may use:
+
+```
+commands/<command-name>.ps1
 ```
 
 ---
 
 # Command Format
 
-All commands must:
+All Bash commands must:
 
 - be executable
 - use bash
@@ -30,6 +36,14 @@ Required header:
 #!/usr/bin/env bash
 set -euo pipefail
 ```
+
+PowerShell bootstrap commands must:
+
+- use lowercase kebab-case filenames
+- enable `Set-StrictMode`
+- fail loudly with `$ErrorActionPreference = 'Stop'`
+- avoid installing software unless the user explicitly requests installation
+- no-op with actionable output outside Windows
 
 ---
 
@@ -77,12 +91,14 @@ Commands should:
 
 # Validation Rules
 
-A command is valid if:
+A Bash command is valid if:
 
 - file is executable
 - contains bash header
 - uses strict mode
 - follows naming conventions
+
+A PowerShell bootstrap command is valid if it follows the PowerShell safety and naming rules above.
 
 ---
 

--- a/commands/create-host-ai-scaffold.sh
+++ b/commands/create-host-ai-scaffold.sh
@@ -3,6 +3,7 @@ set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$script_dir/lib/memory-common.sh"
+source "$script_dir/lib/platform-common.sh"
 opencaw_resolve_paths
 
 opencaw_root="$OPENCAW_ROOT"
@@ -69,6 +70,63 @@ EOF
 
 ensure_host_agents_bootstrap
 
+ensure_windows_bash_guidance() {
+  local baseline_relative installer_reference guidance_file guidance_content
+
+  opencaw_is_windows_host || return 0
+
+  if [[ "$host_root" == "$opencaw_root" ]]; then
+    installer_reference='./commands/install-windows-bash.ps1'
+  else
+    baseline_relative="${opencaw_root#"$host_root"/}"
+    installer_reference="./$baseline_relative/commands/install-windows-bash.ps1"
+  fi
+
+  guidance_file="$host_ai_dir/WINDOWS_BASH.md"
+  if [[ ! -f "$guidance_file" ]]; then
+    guidance_content="$(cat <<'EOF'
+# Windows Bash Setup
+
+OpenCaw commands use Bash. On Windows, prefer Git Bash for native Windows filesystem performance; use WSL when Linux tool compatibility is more important.
+
+The scaffold never installs software automatically. Run these commands from the repository root in PowerShell.
+
+## Check for an existing provider
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "__OPENCAW_WINDOWS_BASH_INSTALLER__"
+```
+
+## Install native Git Bash (recommended)
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "__OPENCAW_WINDOWS_BASH_INSTALLER__" -Provider GitBash -Install
+```
+
+## Install WSL Bash
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "__OPENCAW_WINDOWS_BASH_INSTALLER__" -Provider WSL -Install
+```
+
+WSL installation can require elevation or a restart.
+
+## Run the OpenCaw scaffold
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "__OPENCAW_WINDOWS_BASH_INSTALLER__" -Provider GitBash -RunScaffold -ProjectRoot .
+```
+
+Linux and macOS should run `./commands/create-host-ai-scaffold.sh` directly; this Windows bootstrap is not needed there.
+EOF
+)"
+    guidance_content="${guidance_content//__OPENCAW_WINDOWS_BASH_INSTALLER__/$installer_reference}"
+    printf '%s\n' "$guidance_content" > "$guidance_file"
+  fi
+
+  echo "WINDOWS_BASH_GUIDANCE=$guidance_file"
+}
+
 mkdir -p \
   "$host_ai_dir/goals" \
   "$host_ai_dir/tasks" \
@@ -82,6 +140,7 @@ mkdir -p \
 
 opencaw_ensure_system_memory
 opencaw_ensure_project_files
+ensure_windows_bash_guidance
 
 mkdir -p "$host_ai_dir/tasks/example-task"
 

--- a/commands/install-windows-bash.ps1
+++ b/commands/install-windows-bash.ps1
@@ -1,0 +1,265 @@
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+    [ValidateSet('Auto', 'GitBash', 'WSL')]
+    [string]$Provider = 'Auto',
+
+    [switch]$Install,
+
+    [switch]$RunScaffold,
+
+    [string]$ProjectRoot,
+
+    [string]$GitBashPath
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Test-OpenCawWindows {
+    if ($env:OS -eq 'Windows_NT') {
+        return $true
+    }
+    if ($PSVersionTable.ContainsKey('Platform')) {
+        return $PSVersionTable.Platform -eq 'Win32NT'
+    }
+    return $false
+}
+
+function Resolve-ExistingGitBash {
+    param([string]$ExplicitPath)
+
+    $candidates = [System.Collections.Generic.List[string]]::new()
+    if ($ExplicitPath) {
+        $candidates.Add($ExplicitPath)
+    }
+
+    if (${env:ProgramFiles}) {
+        $candidates.Add((Join-Path ${env:ProgramFiles} 'Git\bin\bash.exe'))
+    }
+    if (${env:ProgramFiles(x86)}) {
+        $candidates.Add((Join-Path ${env:ProgramFiles(x86)} 'Git\bin\bash.exe'))
+    }
+    if ($env:LOCALAPPDATA) {
+        $candidates.Add((Join-Path $env:LOCALAPPDATA 'Programs\Git\bin\bash.exe'))
+    }
+
+    $gitCommand = Get-Command git.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($gitCommand) {
+        $gitRoot = Split-Path -Parent (Split-Path -Parent $gitCommand.Source)
+        $candidates.Add((Join-Path $gitRoot 'bin\bash.exe'))
+        $candidates.Add((Join-Path $gitRoot 'usr\bin\bash.exe'))
+    }
+
+    $pathBash = Get-Command bash.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if ($pathBash -and $pathBash.Source -match '(?i)[\\/](Git|MSYS2?)[\\/]') {
+        $candidates.Add($pathBash.Source)
+    }
+
+    foreach ($candidate in $candidates) {
+        if ($candidate -and (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ExistingWsl {
+    $wslCommand = Get-Command wsl.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $wslCommand) {
+        return $null
+    }
+
+    $distributionOutput = & $wslCommand.Source --list --quiet 2>$null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $distributions = @(
+        $distributionOutput |
+            ForEach-Object { ([string]$_).Replace([char]0, [char]32).Trim() } |
+            Where-Object { $_ }
+    )
+    if ($distributions.Count -eq 0) {
+        return $null
+    }
+
+    return $wslCommand.Source
+}
+
+function Install-GitBash {
+    $winget = Get-Command winget.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $winget) {
+        throw 'winget.exe is unavailable. Install Git for Windows manually, then rerun this command without -Install.'
+    }
+
+    $arguments = @(
+        'install',
+        '--id', 'Git.Git',
+        '--exact',
+        '--source', 'winget',
+        '--accept-source-agreements',
+        '--accept-package-agreements'
+    )
+    if ($PSCmdlet.ShouldProcess('Git for Windows (Git Bash)', "$($winget.Source) $($arguments -join ' ')")) {
+        & $winget.Source @arguments
+        if ($LASTEXITCODE -ne 0) {
+            throw "winget failed to install Git for Windows (exit $LASTEXITCODE)."
+        }
+    }
+}
+
+function Install-WslBash {
+    $wsl = Get-Command wsl.exe -ErrorAction SilentlyContinue | Select-Object -First 1
+    if (-not $wsl) {
+        throw 'wsl.exe is unavailable. Enable the Windows Subsystem for Linux optional feature or choose -Provider GitBash.'
+    }
+
+    if ($PSCmdlet.ShouldProcess('Windows Subsystem for Linux', "$($wsl.Source) --install")) {
+        & $wsl.Source --install
+        if ($LASTEXITCODE -ne 0) {
+            throw "wsl.exe --install failed (exit $LASTEXITCODE)."
+        }
+        Write-Output 'WINDOWS_BASH_RESTART_MAY_BE_REQUIRED=true'
+    }
+}
+
+function Resolve-Provider {
+    param([string]$RequestedProvider)
+
+    if ($RequestedProvider -in @('Auto', 'GitBash')) {
+        $gitBash = Resolve-ExistingGitBash -ExplicitPath $GitBashPath
+        if ($gitBash) {
+            return [pscustomobject]@{ Name = 'GitBash'; Command = $gitBash }
+        }
+    }
+
+    if ($RequestedProvider -in @('Auto', 'WSL')) {
+        $wsl = Resolve-ExistingWsl
+        if ($wsl) {
+            return [pscustomobject]@{ Name = 'WSL'; Command = $wsl }
+        }
+    }
+
+    return $null
+}
+
+function Resolve-ProjectRoot {
+    param([string]$RequestedRoot)
+
+    if (-not $RequestedRoot) {
+        return $null
+    }
+    if (-not (Test-Path -LiteralPath $RequestedRoot -PathType Container)) {
+        throw "Project root does not exist: $RequestedRoot"
+    }
+    return (Resolve-Path -LiteralPath $RequestedRoot).Path
+}
+
+function Invoke-OpenCawScaffold {
+    param(
+        [pscustomobject]$SelectedProvider,
+        [string]$ResolvedProjectRoot
+    )
+
+    $scaffoldScript = Join-Path $PSScriptRoot 'create-host-ai-scaffold.sh'
+    if (-not (Test-Path -LiteralPath $scaffoldScript -PathType Leaf)) {
+        throw "OpenCaw scaffold command not found: $scaffoldScript"
+    }
+
+    $scaffoldTarget = if ($ResolvedProjectRoot) { $ResolvedProjectRoot } else { 'auto-resolved project' }
+    if (-not $PSCmdlet.ShouldProcess($scaffoldTarget, "Run scaffold with $($SelectedProvider.Name)")) {
+        return
+    }
+
+    if ($SelectedProvider.Name -eq 'GitBash') {
+        $previousProjectRoot = $env:OPENCAW_PROJECT_ROOT
+        try {
+            if ($ResolvedProjectRoot) {
+                $env:OPENCAW_PROJECT_ROOT = $ResolvedProjectRoot
+            }
+            & $SelectedProvider.Command $scaffoldScript
+            if ($LASTEXITCODE -ne 0) {
+                throw "OpenCaw scaffold failed under Git Bash (exit $LASTEXITCODE)."
+            }
+        }
+        finally {
+            $env:OPENCAW_PROJECT_ROOT = $previousProjectRoot
+        }
+        return
+    }
+
+    $openCawRoot = Split-Path -Parent $PSScriptRoot
+    $arguments = [System.Collections.Generic.List[string]]::new()
+    $arguments.Add('--cd')
+    $arguments.Add($openCawRoot)
+    if ($ResolvedProjectRoot) {
+        $wslProjectOutput = @(& $SelectedProvider.Command --cd $ResolvedProjectRoot pwd)
+        $wslProjectRoot = ($wslProjectOutput -join "`n").Trim()
+        if ($LASTEXITCODE -ne 0 -or -not $wslProjectRoot) {
+            throw 'Unable to resolve the project-root path through WSL.'
+        }
+        $arguments.Add('env')
+        $arguments.Add("OPENCAW_PROJECT_ROOT=$wslProjectRoot")
+    }
+    $arguments.Add('bash')
+    $arguments.Add('./commands/create-host-ai-scaffold.sh')
+
+    & $SelectedProvider.Command @arguments
+    if ($LASTEXITCODE -ne 0) {
+        throw "OpenCaw scaffold failed under WSL (exit $LASTEXITCODE)."
+    }
+}
+
+if (-not (Test-OpenCawWindows)) {
+    Write-Output 'WINDOWS_BASH_STATUS=NOT_REQUIRED'
+    Write-Output 'WINDOWS_BASH_REASON=Linux and macOS use their existing Bash runtime.'
+    exit 0
+}
+
+$selected = Resolve-Provider -RequestedProvider $Provider
+if (-not $selected -and $Install) {
+    $installProvider = if ($Provider -eq 'Auto') { 'GitBash' } else { $Provider }
+    if ($installProvider -eq 'GitBash') {
+        Install-GitBash
+    }
+    else {
+        Install-WslBash
+    }
+
+    if ($WhatIfPreference) {
+        Write-Output 'WINDOWS_BASH_STATUS=INSTALL_PLANNED'
+        Write-Output "WINDOWS_BASH_PROVIDER=$installProvider"
+        exit 0
+    }
+
+    $selected = Resolve-Provider -RequestedProvider $installProvider
+}
+
+if (-not $selected) {
+    $recommendedProvider = if ($Provider -eq 'Auto') { 'GitBash' } else { $Provider }
+    Write-Output 'WINDOWS_BASH_STATUS=MISSING'
+    Write-Output "WINDOWS_BASH_RECOMMENDED_PROVIDER=$recommendedProvider"
+    Write-Output "WINDOWS_BASH_INSTALL_COMMAND=powershell -NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`" -Provider $recommendedProvider -Install"
+    Write-Error 'No usable Bash provider was found. No software was installed; rerun with -Install or install the provider manually.' -ErrorAction Continue
+    exit 2
+}
+
+Write-Output 'WINDOWS_BASH_STATUS=FOUND'
+Write-Output "WINDOWS_BASH_PROVIDER=$($selected.Name)"
+Write-Output "WINDOWS_BASH_COMMAND=$($selected.Command)"
+Write-Output 'WINDOWS_BASH_INSTALL_REQUIRED=false'
+
+if ($RunScaffold) {
+    $resolvedRoot = Resolve-ProjectRoot -RequestedRoot $ProjectRoot
+    Invoke-OpenCawScaffold -SelectedProvider $selected -ResolvedProjectRoot $resolvedRoot
+    if ($WhatIfPreference) {
+        Write-Output 'OPENCAW_SCAFFOLD_RUN=planned'
+    }
+    else {
+        Write-Output 'OPENCAW_SCAFFOLD_RUN=true'
+    }
+}
+else {
+    Write-Output 'OPENCAW_SCAFFOLD_RUN=false'
+}

--- a/commands/lib/platform-common.sh
+++ b/commands/lib/platform-common.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+# Shared host-platform helpers. Commands sourcing this file must enable strict mode.
+
+opencaw_is_windows_host() {
+  local kernel="${1:-}"
+  local version_text="${2:-}"
+
+  [[ -n "$kernel" ]] || kernel="$(uname -s 2>/dev/null || true)"
+  if [[ -z "$version_text" && -r /proc/version ]]; then
+    version_text="$(< /proc/version)"
+  fi
+
+  case "$kernel" in
+    MINGW*|MSYS*|CYGWIN*) return 0 ;;
+  esac
+
+  [[ -n "${WSL_INTEROP:-}" || "$version_text" =~ [Mm]icrosoft ]]
+}

--- a/commands/validate-commands.sh
+++ b/commands/validate-commands.sh
@@ -43,6 +43,26 @@ while IFS= read -r -d '' cmd; do
 
 done < <(find "$commands_dir" -maxdepth 1 -type f -name "*.sh" -print0)
 
+while IFS= read -r -d '' cmd; do
+  name="$(basename "$cmd")"
+
+  if [[ ! "$name" =~ ^[a-z0-9]+(-[a-z0-9]+)*\.ps1$ ]]; then
+    echo "Invalid PowerShell command name: $name" >&2
+    status=1
+  fi
+
+  if ! grep -Eq '^[[:space:]]*Set-StrictMode([[:space:]]+-Version)?[[:space:]]+' "$cmd"; then
+    echo "Missing PowerShell strict mode in $cmd" >&2
+    status=1
+  fi
+
+  if ! grep -Eq '^\$ErrorActionPreference[[:space:]]*=' "$cmd" \
+    || ! grep -Eq '^\$ErrorActionPreference.*Stop' "$cmd"; then
+    echo "Missing stop-on-error preference in $cmd" >&2
+    status=1
+  fi
+done < <(find "$commands_dir" -maxdepth 1 -type f -name "*.ps1" -print0)
+
 if [[ $status -eq 0 ]]; then
   echo "Commands validation passed."
 fi

--- a/commands/validate-opencaw.sh
+++ b/commands/validate-opencaw.sh
@@ -9,5 +9,6 @@ set -euo pipefail
 ./commands/validate-role-language-alignment.sh
 ./commands/validate-cloud-preferences.sh
 ./tests/test-memory-system.sh
+./tests/test-windows-bash-bootstrap.sh
 
 echo "OpenCaw validation passed."

--- a/commands/validate-role-skill-map.sh
+++ b/commands/validate-role-skill-map.sh
@@ -25,7 +25,7 @@ for (const domain of fs.readdirSync(rolesRoot, { withFileTypes: true }).filter(e
 roles.sort();
 const roleSet = new Set(roles);
 const skillSet = new Set(fs.readdirSync(skillsRoot, { withFileTypes: true }).filter(entry => entry.isDirectory() && fs.existsSync(path.join(skillsRoot, entry.name, 'SKILL.md'))).map(entry => entry.name));
-const commandSet = new Set(fs.readdirSync(commandsRoot, { withFileTypes: true }).filter(entry => entry.isFile() && /^[a-z0-9]+(?:-[a-z0-9]+)*\.sh$/.test(entry.name)).map(entry => `commands/${entry.name}`));
+const commandSet = new Set(fs.readdirSync(commandsRoot, { withFileTypes: true }).filter(entry => entry.isFile() && /^[a-z0-9]+(?:-[a-z0-9]+)*\.(?:sh|ps1)$/.test(entry.name)).map(entry => `commands/${entry.name}`));
 const errors = [];
 
 const expectedKeyOrder = ['__shared__', ...roles];

--- a/skills/INDEX.md
+++ b/skills/INDEX.md
@@ -4,7 +4,7 @@ Curated reusable skills included in OpenCaw.
 
 ## Task And Governance
 
-- `create-host-ai-scaffold` - Ensure host-repository `.ai` scaffolding and OpenCaw bootstrap wiring are in place.
+- `create-host-ai-scaffold` - Ensure host-repository `.ai` scaffolding, Windows Bash guidance when applicable, and OpenCaw bootstrap wiring are in place.
 - `create-task-file` - Create a detailed task folder and TASK.md, then create/link a matching GitHub issue and track it.
 - `goal-flow` - Manage explicitly requested automated goals across task completion, automatic PR creation, post-PR QA, branch chaining, and final human approval reporting.
 - `manage-task-issues` - Maintain one GitHub issue per task and keep only open issue URLs in tracking.

--- a/skills/create-host-ai-scaffold/SKILL.md
+++ b/skills/create-host-ai-scaffold/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: create-host-ai-scaffold
-description: Create the repository-local Memory v2 scaffold, seed protected system memory under the project `.ai` directory, and ensure host AGENTS bootstrap points to OpenCaw when missing. Use at first startup or when required memory, map, task, or bootstrap artifacts are absent.
+description: Create the repository-local Memory v2 scaffold, seed protected system memory, add Windows Bash guidance when applicable, and ensure host AGENTS bootstrap points to OpenCaw when missing. Use at first startup or when required memory, map, task, or bootstrap artifacts are absent.
 ---
 
 ## When to use
@@ -12,6 +12,10 @@ Use when the host repo does not yet have the expected `.ai` structure or when Op
 - Host root `AGENTS.md` includes a managed OpenCaw bootstrap block.
 - Existing host `AGENTS.md` content is preserved; bootstrap block is appended only if missing.
 - Legacy untagged memory is reported for AI-classified migration and is never silently rewritten.
+- Windows hosts receive `.ai/WINDOWS_BASH.md` with safe Git Bash and WSL setup commands; Linux and macOS do not need the Windows bootstrap.
+- Scaffold creation never installs Bash automatically.
 
-## Command
-../commands/create-host-ai-scaffold.sh
+## Commands
+
+- `../commands/create-host-ai-scaffold.sh`
+- Windows before Bash is available: `../commands/install-windows-bash.ps1`

--- a/tests/test-windows-bash-bootstrap.ps1
+++ b/tests/test-windows-bash-bootstrap.ps1
@@ -1,0 +1,68 @@
+[CmdletBinding()]
+param()
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-True {
+    param(
+        [bool]$Condition,
+        [string]$Message
+    )
+    if (-not $Condition) {
+        throw "FAIL: $Message"
+    }
+}
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$installer = Join-Path $repoRoot 'commands\install-windows-bash.ps1'
+$installerText = Get-Content -Raw -LiteralPath $installer
+$null = [scriptblock]::Create($installerText)
+
+if ($env:OS -ne 'Windows_NT') {
+    $output = @(& $installer)
+    Assert-True ($output -contains 'WINDOWS_BASH_STATUS=NOT_REQUIRED') 'non-Windows execution was not a clean no-op'
+    Write-Output 'Windows Bash PowerShell tests passed (non-Windows no-op).'
+    exit 0
+}
+
+$tempParent = [System.IO.Path]::GetTempPath()
+$tempRoot = Join-Path $tempParent ("opencaw-windows-bash-{0}" -f [guid]::NewGuid().ToString('N'))
+$resolvedTempParent = [System.IO.Path]::GetFullPath($tempParent)
+$resolvedTempRoot = [System.IO.Path]::GetFullPath($tempRoot)
+Assert-True ($resolvedTempRoot.StartsWith($resolvedTempParent, [System.StringComparison]::OrdinalIgnoreCase)) 'temporary test root escaped the system temp directory'
+
+New-Item -ItemType Directory -Path $tempRoot | Out-Null
+try {
+    $fakeBash = Join-Path $tempRoot 'bash.exe'
+    Set-Content -LiteralPath $fakeBash -Value 'fixture' -NoNewline
+
+    $discoveryOutput = @(& $installer -Provider GitBash -GitBashPath $fakeBash)
+    Assert-True ($discoveryOutput -contains 'WINDOWS_BASH_STATUS=FOUND') 'explicit Git Bash discovery failed'
+    Assert-True ($discoveryOutput -contains 'WINDOWS_BASH_PROVIDER=GitBash') 'Git Bash provider was not selected'
+    Assert-True ($discoveryOutput -contains "WINDOWS_BASH_COMMAND=$fakeBash") 'resolved Git Bash path was not reported'
+    Assert-True ($discoveryOutput -contains 'OPENCAW_SCAFFOLD_RUN=false') 'discovery unexpectedly ran the scaffold'
+
+    $plannedOutput = @(& $installer -Provider GitBash -GitBashPath $fakeBash -RunScaffold -ProjectRoot $repoRoot -WhatIf)
+    Assert-True ($plannedOutput -contains 'OPENCAW_SCAFFOLD_RUN=planned') 'WhatIf did not report a planned scaffold run'
+
+    $invalidRootFailed = $false
+    try {
+        & $installer -Provider GitBash -GitBashPath $fakeBash -RunScaffold -ProjectRoot (Join-Path $tempRoot 'missing') 2>$null | Out-Null
+    }
+    catch {
+        $invalidRootFailed = $true
+    }
+    Assert-True $invalidRootFailed 'missing project root was accepted'
+
+    Assert-True ($installerText -match "'Git.Git'") 'Git Bash winget package id is missing'
+    Assert-True ($installerText -match 'ShouldProcess') 'installation and scaffold actions are not guarded by ShouldProcess'
+    Assert-True ($installerText -match '--install') 'WSL installation path is missing'
+}
+finally {
+    if (Test-Path -LiteralPath $resolvedTempRoot) {
+        Remove-Item -LiteralPath $resolvedTempRoot -Recurse -Force
+    }
+}
+
+Write-Output 'Windows Bash PowerShell tests passed.'

--- a/tests/test-windows-bash-bootstrap.sh
+++ b/tests/test-windows-bash-bootstrap.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+source commands/lib/platform-common.sh
+
+temp_root="$(mktemp -d)"
+trap 'rm -rf -- "$temp_root"' EXIT
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+
+echo '[1/4] classifying Windows and non-Windows hosts'
+WSL_INTEROP='' opencaw_is_windows_host 'MINGW64_NT-10.0' '' || fail 'Git Bash host was not detected as Windows'
+WSL_INTEROP='' opencaw_is_windows_host 'MSYS_NT-10.0' '' || fail 'MSYS host was not detected as Windows'
+WSL_INTEROP='' opencaw_is_windows_host 'CYGWIN_NT-10.0' '' || fail 'Cygwin host was not detected as Windows'
+WSL_INTEROP='' opencaw_is_windows_host 'Linux' 'Linux version with Microsoft WSL2' || fail 'WSL host was not detected as Windows'
+if WSL_INTEROP='' opencaw_is_windows_host 'Linux' 'generic Linux kernel'; then fail 'generic Linux was classified as Windows'; fi
+if WSL_INTEROP='' opencaw_is_windows_host 'Darwin' 'Darwin kernel'; then fail 'macOS was classified as Windows'; fi
+
+echo '[2/4] generating Windows-only scaffold guidance'
+fixture="$temp_root/project"
+mkdir -p "$fixture/.codex/commands/lib"
+cp commands/create-host-ai-scaffold.sh "$fixture/.codex/commands/create-host-ai-scaffold.sh"
+cp commands/install-windows-bash.ps1 "$fixture/.codex/commands/install-windows-bash.ps1"
+cp commands/lib/memory-common.sh "$fixture/.codex/commands/lib/memory-common.sh"
+cp commands/lib/platform-common.sh "$fixture/.codex/commands/lib/platform-common.sh"
+chmod +x "$fixture/.codex/commands/create-host-ai-scaffold.sh"
+
+WSL_INTEROP='fixture' bash "$fixture/.codex/commands/create-host-ai-scaffold.sh" > "$temp_root/scaffold-first.log"
+guidance="$fixture/.ai/WINDOWS_BASH.md"
+[[ -f "$guidance" ]] || fail 'Windows scaffold guidance was not created'
+grep -Fq './.codex/commands/install-windows-bash.ps1' "$guidance" || fail 'mounted installer path is incorrect'
+grep -Fq -- '-Provider GitBash -Install' "$guidance" || fail 'native Git Bash install guidance is missing'
+grep -Fq -- '-Provider WSL -Install' "$guidance" || fail 'WSL install guidance is missing'
+grep -Fq 'never installs software automatically' "$guidance" || fail 'explicit-install safety guidance is missing'
+
+echo '[3/4] preserving scaffold idempotence'
+guidance_fingerprint="$(sha256sum "$guidance" | awk '{print $1}')"
+WSL_INTEROP='fixture' bash "$fixture/.codex/commands/create-host-ai-scaffold.sh" > "$temp_root/scaffold-second.log"
+[[ "$(sha256sum "$guidance" | awk '{print $1}')" == "$guidance_fingerprint" ]] || fail 'Windows guidance changed on an idempotent scaffold run'
+[[ "$(grep -c '^# Windows Bash Setup$' "$guidance")" -eq 1 ]] || fail 'Windows guidance was duplicated'
+
+echo '[4/4] validating the native PowerShell bootstrap when available'
+powershell_bin=''
+if command -v pwsh >/dev/null 2>&1; then
+  powershell_bin="$(command -v pwsh)"
+elif command -v powershell.exe >/dev/null 2>&1; then
+  powershell_bin="$(command -v powershell.exe)"
+fi
+
+if [[ -n "$powershell_bin" ]]; then
+  powershell_test_path="$repo_root/tests/test-windows-bash-bootstrap.ps1"
+  if [[ "${powershell_bin,,}" == *.exe ]] && command -v wslpath >/dev/null 2>&1; then
+    powershell_test_path="$(wslpath -w "$powershell_test_path")"
+  fi
+  "$powershell_bin" -NoProfile -ExecutionPolicy Bypass -File "$powershell_test_path"
+else
+  echo 'PowerShell unavailable; runtime PowerShell checks skipped on this non-Windows host.'
+fi
+
+echo 'Windows Bash bootstrap tests passed.'


### PR DESCRIPTION
## Summary

Add a Windows-first Bash discovery, installation, and scaffold bootstrap while leaving Linux and macOS setup unchanged.

Closes #75

## What changed

- Add `commands/install-windows-bash.ps1`, which works before Bash is available.
- Prefer an existing native Git Bash for Windows filesystem performance.
- Support explicit Git Bash installation through `winget` and explicit WSL installation through `wsl.exe --install`.
- Require `-Install` for software installation and support `-WhatIf` previews.
- Allow the selected Git Bash or WSL provider to invoke the canonical `create-host-ai-scaffold.sh` command.
- Generate `.ai/WINDOWS_BASH.md` only for Windows, Git Bash/MSYS/Cygwin, or WSL hosts.
- Extend command schemas, validators, role mappings, scaffold guidance, documentation, memory, and repository-map entries.
- Add isolated Bash and PowerShell regression tests.

## Why

OpenCaw's Bash commands can be unavailable or unnecessarily slow on Windows when the shell provider is missing or when every invocation crosses the WSL filesystem boundary. Windows needs a native bootstrap that can run before Bash exists and lets users deliberately choose native speed or Linux compatibility.

## User and developer impact

- Windows users get actionable provider discovery without installing anything.
- Git Bash is the recommended native provider; WSL remains available for Linux tooling compatibility.
- Linux and macOS continue using their existing Bash runtime without Windows-specific setup.
- Scaffold creation never installs software implicitly.

## Risks

- Actual Git Bash installation requires `winget`; missing `winget` returns manual guidance.
- WSL installation can require elevation or a restart.
- PowerShell execution policies may require the documented `-ExecutionPolicy Bypass` invocation.

## Validation

- Isolated Windows bootstrap tests under WSL Bash and native Git Bash.
- PowerShell 7 and Windows PowerShell 5.1 parsing and behavior tests.
- Successful canonical scaffold execution through both Git Bash and WSL.
- `bash tests/test-memory-system.sh`
- `bash commands/validate-opencaw.sh`
- `bash tests/test-capability-expansion.sh`
- `bash commands/validate-memory.sh`
- current repository-map fingerprint
- `git diff --check`

All checks passed. No software installation was performed.

## Deployment and rollback

No deployment action is required. Revert commit `7a01990` to remove the Windows bootstrap and guidance.
