### PR TITLE
chore(tasks): remove closed issue from tracker

### DIFF
--- a/.ai/tasks/OPEN_ISSUES.md
+++ b/.ai/tasks/OPEN_ISSUES.md
@@ -1,1 +1,0 @@
-https://github.com/TimothyMeadows/OpenCaw/issues/75


### PR DESCRIPTION
## Summary

Remove closed issue #75 from the repository's open-task tracker.

## What changed

- Removed the stale issue URL from `.ai/tasks/OPEN_ISSUES.md`.

## Why

The issue was closed after its task completed, but its URL remained in the file reserved for open GitHub issues. This caused the repository's task state to disagree with GitHub.

## Impact and risks

- Documentation/task-tracking only; no runtime or deployment impact.
- Risk is limited to the tracker no longer listing an already-closed issue.

## Validation

- Confirmed GitHub issue #75 is closed.
- Ran `commands/sync-task-issues.sh`; it reports zero tracked URLs and no unresolved entries.
- Ran `git diff --check origin/main...HEAD`; passed.
- Ran `commands/validate-opencaw.sh`; it reached the unrelated existing `.media/CLOUD_SESSION.md` heading failure. That file is unchanged from `origin/main`.

## Deployment / rollback

- No deployment required.
- Roll back by restoring the issue URL if the issue is reopened.

Follow-up to #75.
