### PR TITLE
Clean completed task state and harden CRLF validation

### DIFF
--- a/.ai/tasks/OPEN_ISSUES.md
+++ b/.ai/tasks/OPEN_ISSUES.md
@@ -1,1 +1,0 @@
-https://github.com/TimothyMeadows/OpenCaw/issues/93

--- a/commands/validate-memory.sh
+++ b/commands/validate-memory.sh
@@ -72,7 +72,7 @@ validate_flat_system_file
 validate_tagged_file "$OPENCAW_PROJECT_MEMORY_FILE" 'project memory'
 validate_tagged_file "$OPENCAW_REPO_MAP_FILE" 'repository map'
 
-if ! grep -Eq '^<!-- OPENCAW_REPO_MAP_FINGERPRINT: (pending|[a-f0-9]{64}) -->$' "$OPENCAW_REPO_MAP_FILE"; then
+if ! tr -d '\r' <"$OPENCAW_REPO_MAP_FILE" | grep -Eq '^<!-- OPENCAW_REPO_MAP_FINGERPRINT: (pending|[a-f0-9]{64}) -->$'; then
   echo 'Repository map is missing a valid fingerprint marker.' >&2
   status=1
 fi

--- a/tests/test-memory-system.sh
+++ b/tests/test-memory-system.sh
@@ -131,6 +131,7 @@ grep -q 'REPO_MAP_STATUS=CURRENT' < <(run_for "$project" bash commands/repo-map-
 awk '{ sub(/\r$/, ""); printf "%s\r\n", $0 }' "$project/.ai/REPO_MAP.md" > "$project/.ai/REPO_MAP.md.tmp"
 mv "$project/.ai/REPO_MAP.md.tmp" "$project/.ai/REPO_MAP.md"
 grep -q 'REPO_MAP_STATUS=CURRENT' < <(run_for "$project" bash commands/repo-map-status.sh) || fail 'CRLF repository-map marker was not recognized'
+run_for "$project" bash commands/validate-memory.sh >/dev/null || fail 'memory validation rejected a CRLF repository-map marker'
 printf 'content-only change\n' >> "$project/app.txt"
 grep -q 'REPO_MAP_STATUS=CURRENT' < <(run_for "$project" bash commands/repo-map-status.sh) || fail 'content-only edit made map stale'
 printf 'new tracked path\n' > "$project/new-component.txt"


### PR DESCRIPTION
## Summary

- removes the final closed task issue URL after the authorized feature PRs merged
- makes repository-map fingerprint validation tolerate normal CRLF checkouts
- adds direct CRLF marker regression coverage to the Memory v2 suite

## Validation

- `commands/sync-task-issues.sh`
- `commands/validate-memory.sh`
- `tests/test-memory-system.sh`
- `commands/validate-commands.sh`
- `git diff --check`